### PR TITLE
Exclude the impact of runner repo path when running diff checker

### DIFF
--- a/dest/index.js
+++ b/dest/index.js
@@ -8925,8 +8925,8 @@ async function main() {
     const coverageReportNew = JSON.parse(external_fs_default().readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(external_fs_default().readFileSync(baseCoverageReportPath).toString());
 
-    console.log('[ coverageReportOld ] >', coverageReportOld.length);
-    console.log('[ coverageReportNew ] >', coverageReportNew.length);
+    console.log('[ coverageReportOld ] >', coverageReportOld);
+    console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = (0,external_child_process_namespaceObject.execSync)('pwd')

--- a/dest/index.js
+++ b/dest/index.js
@@ -8556,7 +8556,7 @@ class DiffChecker {
     this.prNumber = prNumber;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]).map
 
     /**
      * For all filePaths in coverage, generate a percentage value
@@ -8589,7 +8589,6 @@ class DiffChecker {
           oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null)
         }
       }
-      console.log('[ this.diffCoverageReport ] >', this.diffCoverageReport)
     }
   }
 
@@ -8709,9 +8708,6 @@ class DiffChecker {
     const fileNewCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.oldPct === 0
     )
-    if (fileNewCoverage) {
-      console.log('[ fileNewCoverage name ] >', name)
-    }
     // No new coverage found so that means we deleted a file coverage
     const fileRemovedCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.newPct === 0
@@ -8791,6 +8787,12 @@ class DiffChecker {
     const diff = Number(diffData.newPct) - Number(diffData.oldPct)
     // round off the diff to 2 decimal places
     return Math.round((diff + Number.EPSILON) * 100) / 100
+  }
+
+  getFileCoverage(report, filePath) {
+    if (report[filePath]) return report[filePath];
+
+    return report[filePath.replace('/runner/_work', '/runner/work')];
   }
 }
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
@@ -8929,8 +8931,8 @@ async function main() {
     const coverageReportNew = JSON.parse(external_fs_default().readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(external_fs_default().readFileSync(baseCoverageReportPath).toString());
 
-    // console.log('[ coverageReportOld ] >', coverageReportOld);
-    // console.log('[ coverageReportNew ] >', coverageReportNew);
+    console.log('[ coverageReportOld ] >', coverageReportOld);
+    console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = (0,external_child_process_namespaceObject.execSync)('pwd')
@@ -8949,13 +8951,11 @@ async function main() {
     let messageToPost = `## Coverage Report \n\n`
 
     messageToPost += `* **Status**: ${isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
-    console.log('messageToPost1!!!', messageToPost.length);
 
     // Add the custom message if it exists
     if (customMessage !== '') {
       messageToPost += `* ${customMessage} \n`;
     }
-    console.log('messageToPost2!!!', messageToPost.length);
 
     // If coverageDetails length is 0 that means there is no change between base and head
     if (remainingStatusLines.length === 0 && decreaseStatusLines.length === 0) {
@@ -8963,20 +8963,17 @@ async function main() {
               '* No changes to code coverage between the master branch and the current head branch'
       messageToPost += '\n--- \n\n'
     } else {
-      console.log('messageToPost3!!!', messageToPost.length);
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {
         messageToPost += `* Current PR reduces the test coverage percentage by ${delta} for some tests \n`
       }
       messageToPost += '--- \n\n'
-      console.log('messageToPost4!!!', messageToPost.length);
       if (decreaseStatusLines.length > 0) {
         messageToPost +=
               'Status | Changes Missing Coverage | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
         messageToPost += decreaseStatusLines.join('\n')
         messageToPost += '\n--- \n\n'
       }
-      console.log('messageToPost5!!!', messageToPost.length);
 
       // Show coverage table for all files that were affected because of this PR
       if (remainingStatusLines.length > 0) {
@@ -8984,12 +8981,10 @@ async function main() {
         messageToPost += '<summary markdown="span">Click to view remaining coverage report</summary>\n\n'
         messageToPost +=
               'Status | File | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
-        console.log('messageToPost6!!!', messageToPost.length);
         messageToPost += remainingStatusLines.join('\n')
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
-        console.log('messageToPost7!!!', messageToPost.length);
       }
     }
 
@@ -9003,12 +8998,10 @@ async function main() {
       messageToPost +=
             `| Total | ${linesTotalPct}% | \n :-----|-----: \n Change from base: | ${lineChangesPct}% \n Covered Lines: | ${linesCovered} \n Total Lines: | ${linesTotal} \n`;
     }
-    console.log('messageToPost8!!!', messageToPost.length);
 
     messageToPost = `${commentIdentifier} \n ${messageToPost}`
     let commentId = null
 
-    console.log('messageToPost9!!!', messageToPost.length);
 
     // If useSameComment is true, then find the comment and then update that comment.
     // If not, then create a new comment

--- a/dest/index.js
+++ b/dest/index.js
@@ -8563,7 +8563,6 @@ class DiffChecker {
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
-      console.log('[ filePath ] >', filePath);
       const newCoverage = coverageReportNew[filePath];
       const oldCoverage = coverageReportOld[filePath];
       this.diffCoverageReport[filePath] = {
@@ -8927,9 +8926,6 @@ async function main() {
     // Read the json summary files for base and branch coverage
     const coverageReportNew = JSON.parse(external_fs_default().readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(external_fs_default().readFileSync(baseCoverageReportPath).toString());
-
-    console.log('[ coverageReportOld ] >', coverageReportOld);
-    console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = (0,external_child_process_namespaceObject.execSync)('pwd')

--- a/dest/index.js
+++ b/dest/index.js
@@ -8563,30 +8563,32 @@ class DiffChecker {
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
+      const newCoverage = this.getFileCoverage(coverageReportNew, filePath);
+      const oldCoverage = this.getFileCoverage(coverageReportOld, filePath);
       this.diffCoverageReport[filePath] = {
         branches: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].branches : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].branches : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].branches : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].branches : null)
+          new: newCoverage ? oldCoverage.branches : null,
+          old: oldCoverage ? oldCoverage.branches : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.branches : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.branches : null)
         },
         statements: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].statements : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].statements : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].statements : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].statements : null)
+          new: newCoverage ? newCoverage.statements : null,
+          old: oldCoverage ? oldCoverage.statements : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.statements : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.statements : null)
         },
         lines: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].lines : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].lines : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].lines : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].lines : null)
+          new: newCoverage ? newCoverage.lines : null,
+          old: oldCoverage ? oldCoverage.lines : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.lines : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.lines : null)
         },
         functions: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].functions : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].functions : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null)
+          new: newCoverage ? newCoverage.functions : null,
+          old: oldCoverage ? oldCoverage.functions : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.functions : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.functions : null)
         }
       }
     }
@@ -8792,7 +8794,7 @@ class DiffChecker {
   getFileCoverage(report, filePath) {
     if (report[filePath]) return report[filePath];
 
-    return report[filePath.replace('/runner/_work', '/runner/work')];
+    return report[filePath.replace('/runner/_work', '/home/runner/work')];
   }
 }
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js

--- a/dest/index.js
+++ b/dest/index.js
@@ -8589,6 +8589,7 @@ class DiffChecker {
           oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null)
         }
       }
+      console.log('[ this.diffCoverageReport ] >', this.diffCoverageReport)
     }
   }
 
@@ -8928,8 +8929,8 @@ async function main() {
     const coverageReportNew = JSON.parse(external_fs_default().readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(external_fs_default().readFileSync(baseCoverageReportPath).toString());
 
-    console.log('[ coverageReportOld ] >', coverageReportOld);
-    console.log('[ coverageReportNew ] >', coverageReportNew);
+    // console.log('[ coverageReportOld ] >', coverageReportOld);
+    // console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = (0,external_child_process_namespaceObject.execSync)('pwd')

--- a/dest/index.js
+++ b/dest/index.js
@@ -8977,12 +8977,12 @@ async function main() {
         messageToPost += '<summary markdown="span">Click to view remaining coverage report</summary>\n\n'
         messageToPost +=
               'Status | File | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
-        console.log('messageToPost6!!!', messageToPost);
+        console.log('messageToPost6!!!', messageToPost.length);
         messageToPost += remainingStatusLines.join('\n')
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
-        console.log('messageToPost7!!!', messageToPost.length);
+        console.log('messageToPost7!!!', messageToPost);
       }
     }
 

--- a/dest/index.js
+++ b/dest/index.js
@@ -3861,7 +3861,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var endpoint = __nccwpck_require__(9440);
 var universalUserAgent = __nccwpck_require__(5030);
 var isPlainObject = __nccwpck_require__(9062);
-var nodeFetch = _interopDefault(__nccwpck_require__(1768));
+var nodeFetch = _interopDefault(__nccwpck_require__(467));
 var requestError = __nccwpck_require__(537);
 
 const VERSION = "5.6.2";
@@ -4079,7 +4079,212 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 1768:
+/***/ 3682:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var register = __nccwpck_require__(4670)
+var addHook = __nccwpck_require__(5549)
+var removeHook = __nccwpck_require__(6819)
+
+// bind with array of arguments: https://stackoverflow.com/a/21792913
+var bind = Function.bind
+var bindable = bind.bind(bind)
+
+function bindApi (hook, state, name) {
+  var removeHookRef = bindable(removeHook, null).apply(null, name ? [state, name] : [state])
+  hook.api = { remove: removeHookRef }
+  hook.remove = removeHookRef
+
+  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
+    var args = name ? [state, kind, name] : [state, kind]
+    hook[kind] = hook.api[kind] = bindable(addHook, null).apply(null, args)
+  })
+}
+
+function HookSingular () {
+  var singularHookName = 'h'
+  var singularHookState = {
+    registry: {}
+  }
+  var singularHook = register.bind(null, singularHookState, singularHookName)
+  bindApi(singularHook, singularHookState, singularHookName)
+  return singularHook
+}
+
+function HookCollection () {
+  var state = {
+    registry: {}
+  }
+
+  var hook = register.bind(null, state)
+  bindApi(hook, state)
+
+  return hook
+}
+
+var collectionHookDeprecationMessageDisplayed = false
+function Hook () {
+  if (!collectionHookDeprecationMessageDisplayed) {
+    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4')
+    collectionHookDeprecationMessageDisplayed = true
+  }
+  return HookCollection()
+}
+
+Hook.Singular = HookSingular.bind()
+Hook.Collection = HookCollection.bind()
+
+module.exports = Hook
+// expose constructors as a named property for TypeScript
+module.exports.Hook = Hook
+module.exports.Singular = Hook.Singular
+module.exports.Collection = Hook.Collection
+
+
+/***/ }),
+
+/***/ 5549:
+/***/ ((module) => {
+
+module.exports = addHook;
+
+function addHook(state, kind, name, hook) {
+  var orig = hook;
+  if (!state.registry[name]) {
+    state.registry[name] = [];
+  }
+
+  if (kind === "before") {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(orig.bind(null, options))
+        .then(method.bind(null, options));
+    };
+  }
+
+  if (kind === "after") {
+    hook = function (method, options) {
+      var result;
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .then(function (result_) {
+          result = result_;
+          return orig(result, options);
+        })
+        .then(function () {
+          return result;
+        });
+    };
+  }
+
+  if (kind === "error") {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .catch(function (error) {
+          return orig(error, options);
+        });
+    };
+  }
+
+  state.registry[name].push({
+    hook: hook,
+    orig: orig,
+  });
+}
+
+
+/***/ }),
+
+/***/ 4670:
+/***/ ((module) => {
+
+module.exports = register;
+
+function register(state, name, method, options) {
+  if (typeof method !== "function") {
+    throw new Error("method for before hook must be a function");
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  if (Array.isArray(name)) {
+    return name.reverse().reduce(function (callback, name) {
+      return register.bind(null, state, name, callback, options);
+    }, method)();
+  }
+
+  return Promise.resolve().then(function () {
+    if (!state.registry[name]) {
+      return method(options);
+    }
+
+    return state.registry[name].reduce(function (method, registered) {
+      return registered.hook.bind(null, method, options);
+    }, method)();
+  });
+}
+
+
+/***/ }),
+
+/***/ 6819:
+/***/ ((module) => {
+
+module.exports = removeHook;
+
+function removeHook(state, name, method) {
+  if (!state.registry[name]) {
+    return;
+  }
+
+  var index = state.registry[name]
+    .map(function (registered) {
+      return registered.orig;
+    })
+    .indexOf(method);
+
+  if (index === -1) {
+    return;
+  }
+
+  state.registry[name].splice(index, 1);
+}
+
+
+/***/ }),
+
+/***/ 8932:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+class Deprecation extends Error {
+  constructor(message) {
+    super(message); // Maintains proper stack trace (only available on V8)
+
+    /* istanbul ignore next */
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = 'Deprecation';
+  }
+
+}
+
+exports.Deprecation = Deprecation;
+
+
+/***/ }),
+
+/***/ 467:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4092,7 +4297,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var Stream = _interopDefault(__nccwpck_require__(2413));
 var http = _interopDefault(__nccwpck_require__(8605));
 var Url = _interopDefault(__nccwpck_require__(8835));
-var whatwgUrl = _interopDefault(__nccwpck_require__(8665));
+var whatwgUrl = _interopDefault(__nccwpck_require__(3323));
 var https = _interopDefault(__nccwpck_require__(7211));
 var zlib = _interopDefault(__nccwpck_require__(8761));
 
@@ -5758,268 +5963,14 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 3682:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-var register = __nccwpck_require__(4670)
-var addHook = __nccwpck_require__(5549)
-var removeHook = __nccwpck_require__(6819)
-
-// bind with array of arguments: https://stackoverflow.com/a/21792913
-var bind = Function.bind
-var bindable = bind.bind(bind)
-
-function bindApi (hook, state, name) {
-  var removeHookRef = bindable(removeHook, null).apply(null, name ? [state, name] : [state])
-  hook.api = { remove: removeHookRef }
-  hook.remove = removeHookRef
-
-  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
-    var args = name ? [state, kind, name] : [state, kind]
-    hook[kind] = hook.api[kind] = bindable(addHook, null).apply(null, args)
-  })
-}
-
-function HookSingular () {
-  var singularHookName = 'h'
-  var singularHookState = {
-    registry: {}
-  }
-  var singularHook = register.bind(null, singularHookState, singularHookName)
-  bindApi(singularHook, singularHookState, singularHookName)
-  return singularHook
-}
-
-function HookCollection () {
-  var state = {
-    registry: {}
-  }
-
-  var hook = register.bind(null, state)
-  bindApi(hook, state)
-
-  return hook
-}
-
-var collectionHookDeprecationMessageDisplayed = false
-function Hook () {
-  if (!collectionHookDeprecationMessageDisplayed) {
-    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4')
-    collectionHookDeprecationMessageDisplayed = true
-  }
-  return HookCollection()
-}
-
-Hook.Singular = HookSingular.bind()
-Hook.Collection = HookCollection.bind()
-
-module.exports = Hook
-// expose constructors as a named property for TypeScript
-module.exports.Hook = Hook
-module.exports.Singular = Hook.Singular
-module.exports.Collection = Hook.Collection
-
-
-/***/ }),
-
-/***/ 5549:
-/***/ ((module) => {
-
-module.exports = addHook;
-
-function addHook(state, kind, name, hook) {
-  var orig = hook;
-  if (!state.registry[name]) {
-    state.registry[name] = [];
-  }
-
-  if (kind === "before") {
-    hook = function (method, options) {
-      return Promise.resolve()
-        .then(orig.bind(null, options))
-        .then(method.bind(null, options));
-    };
-  }
-
-  if (kind === "after") {
-    hook = function (method, options) {
-      var result;
-      return Promise.resolve()
-        .then(method.bind(null, options))
-        .then(function (result_) {
-          result = result_;
-          return orig(result, options);
-        })
-        .then(function () {
-          return result;
-        });
-    };
-  }
-
-  if (kind === "error") {
-    hook = function (method, options) {
-      return Promise.resolve()
-        .then(method.bind(null, options))
-        .catch(function (error) {
-          return orig(error, options);
-        });
-    };
-  }
-
-  state.registry[name].push({
-    hook: hook,
-    orig: orig,
-  });
-}
-
-
-/***/ }),
-
-/***/ 4670:
-/***/ ((module) => {
-
-module.exports = register;
-
-function register(state, name, method, options) {
-  if (typeof method !== "function") {
-    throw new Error("method for before hook must be a function");
-  }
-
-  if (!options) {
-    options = {};
-  }
-
-  if (Array.isArray(name)) {
-    return name.reverse().reduce(function (callback, name) {
-      return register.bind(null, state, name, callback, options);
-    }, method)();
-  }
-
-  return Promise.resolve().then(function () {
-    if (!state.registry[name]) {
-      return method(options);
-    }
-
-    return state.registry[name].reduce(function (method, registered) {
-      return registered.hook.bind(null, method, options);
-    }, method)();
-  });
-}
-
-
-/***/ }),
-
-/***/ 6819:
-/***/ ((module) => {
-
-module.exports = removeHook;
-
-function removeHook(state, name, method) {
-  if (!state.registry[name]) {
-    return;
-  }
-
-  var index = state.registry[name]
-    .map(function (registered) {
-      return registered.orig;
-    })
-    .indexOf(method);
-
-  if (index === -1) {
-    return;
-  }
-
-  state.registry[name].splice(index, 1);
-}
-
-
-/***/ }),
-
-/***/ 8932:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-class Deprecation extends Error {
-  constructor(message) {
-    super(message); // Maintains proper stack trace (only available on V8)
-
-    /* istanbul ignore next */
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-
-    this.name = 'Deprecation';
-  }
-
-}
-
-exports.Deprecation = Deprecation;
-
-
-/***/ }),
-
-/***/ 1223:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-var wrappy = __nccwpck_require__(2940)
-module.exports = wrappy(once)
-module.exports.strict = wrappy(onceStrict)
-
-once.proto = once(function () {
-  Object.defineProperty(Function.prototype, 'once', {
-    value: function () {
-      return once(this)
-    },
-    configurable: true
-  })
-
-  Object.defineProperty(Function.prototype, 'onceStrict', {
-    value: function () {
-      return onceStrict(this)
-    },
-    configurable: true
-  })
-})
-
-function once (fn) {
-  var f = function () {
-    if (f.called) return f.value
-    f.called = true
-    return f.value = fn.apply(this, arguments)
-  }
-  f.called = false
-  return f
-}
-
-function onceStrict (fn) {
-  var f = function () {
-    if (f.called)
-      throw new Error(f.onceError)
-    f.called = true
-    return f.value = fn.apply(this, arguments)
-  }
-  var name = fn.name || 'Function wrapped with `once`'
-  f.onceError = name + " shouldn't be called more than once"
-  f.called = false
-  return f
-}
-
-
-/***/ }),
-
-/***/ 4256:
+/***/ 2299:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 var punycode = __nccwpck_require__(4213);
-var mappingTable = __nccwpck_require__(68);
+var mappingTable = __nccwpck_require__(8661);
 
 var PROCESSING_OPTIONS = {
   TRANSITIONAL: 0,
@@ -6213,318 +6164,209 @@ module.exports.PROCESSING_OPTIONS = PROCESSING_OPTIONS;
 
 /***/ }),
 
-/***/ 4294:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-module.exports = __nccwpck_require__(4219);
-
-
-/***/ }),
-
-/***/ 4219:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ 5871:
+/***/ ((module) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(1631);
-var tls = __nccwpck_require__(4016);
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var events = __nccwpck_require__(8614);
-var assert = __nccwpck_require__(2357);
-var util = __nccwpck_require__(1669);
+var conversions = {};
+module.exports = conversions;
 
-
-exports.httpOverHttp = httpOverHttp;
-exports.httpsOverHttp = httpsOverHttp;
-exports.httpOverHttps = httpOverHttps;
-exports.httpsOverHttps = httpsOverHttps;
-
-
-function httpOverHttp(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = http.request;
-  return agent;
+function sign(x) {
+    return x < 0 ? -1 : 1;
 }
 
-function httpsOverHttp(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = http.request;
-  agent.createSocket = createSecureSocket;
-  agent.defaultPort = 443;
-  return agent;
-}
-
-function httpOverHttps(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = https.request;
-  return agent;
-}
-
-function httpsOverHttps(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = https.request;
-  agent.createSocket = createSecureSocket;
-  agent.defaultPort = 443;
-  return agent;
-}
-
-
-function TunnelingAgent(options) {
-  var self = this;
-  self.options = options || {};
-  self.proxyOptions = self.options.proxy || {};
-  self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
-  self.requests = [];
-  self.sockets = [];
-
-  self.on('free', function onFree(socket, host, port, localAddress) {
-    var options = toOptions(host, port, localAddress);
-    for (var i = 0, len = self.requests.length; i < len; ++i) {
-      var pending = self.requests[i];
-      if (pending.host === options.host && pending.port === options.port) {
-        // Detect the request to connect same origin server,
-        // reuse the connection.
-        self.requests.splice(i, 1);
-        pending.request.onSocket(socket);
-        return;
-      }
-    }
-    socket.destroy();
-    self.removeSocket(socket);
-  });
-}
-util.inherits(TunnelingAgent, events.EventEmitter);
-
-TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
-  var self = this;
-  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
-
-  if (self.sockets.length >= this.maxSockets) {
-    // We are over limit so we'll add it to the queue.
-    self.requests.push(options);
-    return;
-  }
-
-  // If we are under maxSockets create a new one.
-  self.createSocket(options, function(socket) {
-    socket.on('free', onFree);
-    socket.on('close', onCloseOrRemove);
-    socket.on('agentRemove', onCloseOrRemove);
-    req.onSocket(socket);
-
-    function onFree() {
-      self.emit('free', socket, options);
-    }
-
-    function onCloseOrRemove(err) {
-      self.removeSocket(socket);
-      socket.removeListener('free', onFree);
-      socket.removeListener('close', onCloseOrRemove);
-      socket.removeListener('agentRemove', onCloseOrRemove);
-    }
-  });
-};
-
-TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
-  var self = this;
-  var placeholder = {};
-  self.sockets.push(placeholder);
-
-  var connectOptions = mergeOptions({}, self.proxyOptions, {
-    method: 'CONNECT',
-    path: options.host + ':' + options.port,
-    agent: false,
-    headers: {
-      host: options.host + ':' + options.port
-    }
-  });
-  if (options.localAddress) {
-    connectOptions.localAddress = options.localAddress;
-  }
-  if (connectOptions.proxyAuth) {
-    connectOptions.headers = connectOptions.headers || {};
-    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
-        new Buffer(connectOptions.proxyAuth).toString('base64');
-  }
-
-  debug('making CONNECT request');
-  var connectReq = self.request(connectOptions);
-  connectReq.useChunkedEncodingByDefault = false; // for v0.6
-  connectReq.once('response', onResponse); // for v0.6
-  connectReq.once('upgrade', onUpgrade);   // for v0.6
-  connectReq.once('connect', onConnect);   // for v0.7 or later
-  connectReq.once('error', onError);
-  connectReq.end();
-
-  function onResponse(res) {
-    // Very hacky. This is necessary to avoid http-parser leaks.
-    res.upgrade = true;
-  }
-
-  function onUpgrade(res, socket, head) {
-    // Hacky.
-    process.nextTick(function() {
-      onConnect(res, socket, head);
-    });
-  }
-
-  function onConnect(res, socket, head) {
-    connectReq.removeAllListeners();
-    socket.removeAllListeners();
-
-    if (res.statusCode !== 200) {
-      debug('tunneling socket could not be established, statusCode=%d',
-        res.statusCode);
-      socket.destroy();
-      var error = new Error('tunneling socket could not be established, ' +
-        'statusCode=' + res.statusCode);
-      error.code = 'ECONNRESET';
-      options.request.emit('error', error);
-      self.removeSocket(placeholder);
-      return;
-    }
-    if (head.length > 0) {
-      debug('got illegal response body from proxy');
-      socket.destroy();
-      var error = new Error('got illegal response body from proxy');
-      error.code = 'ECONNRESET';
-      options.request.emit('error', error);
-      self.removeSocket(placeholder);
-      return;
-    }
-    debug('tunneling connection has established');
-    self.sockets[self.sockets.indexOf(placeholder)] = socket;
-    return cb(socket);
-  }
-
-  function onError(cause) {
-    connectReq.removeAllListeners();
-
-    debug('tunneling socket could not be established, cause=%s\n',
-          cause.message, cause.stack);
-    var error = new Error('tunneling socket could not be established, ' +
-                          'cause=' + cause.message);
-    error.code = 'ECONNRESET';
-    options.request.emit('error', error);
-    self.removeSocket(placeholder);
-  }
-};
-
-TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
-  var pos = this.sockets.indexOf(socket)
-  if (pos === -1) {
-    return;
-  }
-  this.sockets.splice(pos, 1);
-
-  var pending = this.requests.shift();
-  if (pending) {
-    // If we have pending requests and a socket gets closed a new one
-    // needs to be created to take over in the pool for the one that closed.
-    this.createSocket(pending, function(socket) {
-      pending.request.onSocket(socket);
-    });
-  }
-};
-
-function createSecureSocket(options, cb) {
-  var self = this;
-  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
-    var hostHeader = options.request.getHeader('host');
-    var tlsOptions = mergeOptions({}, self.options, {
-      socket: socket,
-      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
-    });
-
-    // 0 is dummy port for v0.6
-    var secureSocket = tls.connect(0, tlsOptions);
-    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
-    cb(secureSocket);
-  });
-}
-
-
-function toOptions(host, port, localAddress) {
-  if (typeof host === 'string') { // since v0.10
-    return {
-      host: host,
-      port: port,
-      localAddress: localAddress
-    };
-  }
-  return host; // for v0.11 or later
-}
-
-function mergeOptions(target) {
-  for (var i = 1, len = arguments.length; i < len; ++i) {
-    var overrides = arguments[i];
-    if (typeof overrides === 'object') {
-      var keys = Object.keys(overrides);
-      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
-        var k = keys[j];
-        if (overrides[k] !== undefined) {
-          target[k] = overrides[k];
-        }
-      }
-    }
-  }
-  return target;
-}
-
-
-var debug;
-if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-  debug = function() {
-    var args = Array.prototype.slice.call(arguments);
-    if (typeof args[0] === 'string') {
-      args[0] = 'TUNNEL: ' + args[0];
+function evenRound(x) {
+    // Round x to the nearest integer, choosing the even integer if it lies halfway between two.
+    if ((x % 1) === 0.5 && (x & 1) === 0) { // [even number].5; round down (i.e. floor)
+        return Math.floor(x);
     } else {
-      args.unshift('TUNNEL:');
+        return Math.round(x);
     }
-    console.error.apply(console, args);
-  }
-} else {
-  debug = function() {};
 }
-exports.debug = debug; // for test
+
+function createNumberConversion(bitLength, typeOpts) {
+    if (!typeOpts.unsigned) {
+        --bitLength;
+    }
+    const lowerBound = typeOpts.unsigned ? 0 : -Math.pow(2, bitLength);
+    const upperBound = Math.pow(2, bitLength) - 1;
+
+    const moduloVal = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength) : Math.pow(2, bitLength);
+    const moduloBound = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength - 1) : Math.pow(2, bitLength - 1);
+
+    return function(V, opts) {
+        if (!opts) opts = {};
+
+        let x = +V;
+
+        if (opts.enforceRange) {
+            if (!Number.isFinite(x)) {
+                throw new TypeError("Argument is not a finite number");
+            }
+
+            x = sign(x) * Math.floor(Math.abs(x));
+            if (x < lowerBound || x > upperBound) {
+                throw new TypeError("Argument is not in byte range");
+            }
+
+            return x;
+        }
+
+        if (!isNaN(x) && opts.clamp) {
+            x = evenRound(x);
+
+            if (x < lowerBound) x = lowerBound;
+            if (x > upperBound) x = upperBound;
+            return x;
+        }
+
+        if (!Number.isFinite(x) || x === 0) {
+            return 0;
+        }
+
+        x = sign(x) * Math.floor(Math.abs(x));
+        x = x % moduloVal;
+
+        if (!typeOpts.unsigned && x >= moduloBound) {
+            return x - moduloVal;
+        } else if (typeOpts.unsigned) {
+            if (x < 0) {
+              x += moduloVal;
+            } else if (x === -0) { // don't return negative zero
+              return 0;
+            }
+        }
+
+        return x;
+    }
+}
+
+conversions["void"] = function () {
+    return undefined;
+};
+
+conversions["boolean"] = function (val) {
+    return !!val;
+};
+
+conversions["byte"] = createNumberConversion(8, { unsigned: false });
+conversions["octet"] = createNumberConversion(8, { unsigned: true });
+
+conversions["short"] = createNumberConversion(16, { unsigned: false });
+conversions["unsigned short"] = createNumberConversion(16, { unsigned: true });
+
+conversions["long"] = createNumberConversion(32, { unsigned: false });
+conversions["unsigned long"] = createNumberConversion(32, { unsigned: true });
+
+conversions["long long"] = createNumberConversion(32, { unsigned: false, moduloBitLength: 64 });
+conversions["unsigned long long"] = createNumberConversion(32, { unsigned: true, moduloBitLength: 64 });
+
+conversions["double"] = function (V) {
+    const x = +V;
+
+    if (!Number.isFinite(x)) {
+        throw new TypeError("Argument is not a finite floating-point value");
+    }
+
+    return x;
+};
+
+conversions["unrestricted double"] = function (V) {
+    const x = +V;
+
+    if (isNaN(x)) {
+        throw new TypeError("Argument is NaN");
+    }
+
+    return x;
+};
+
+// not quite valid, but good enough for JS
+conversions["float"] = conversions["double"];
+conversions["unrestricted float"] = conversions["unrestricted double"];
+
+conversions["DOMString"] = function (V, opts) {
+    if (!opts) opts = {};
+
+    if (opts.treatNullAsEmptyString && V === null) {
+        return "";
+    }
+
+    return String(V);
+};
+
+conversions["ByteString"] = function (V, opts) {
+    const x = String(V);
+    let c = undefined;
+    for (let i = 0; (c = x.codePointAt(i)) !== undefined; ++i) {
+        if (c > 255) {
+            throw new TypeError("Argument is not a valid bytestring");
+        }
+    }
+
+    return x;
+};
+
+conversions["USVString"] = function (V) {
+    const S = String(V);
+    const n = S.length;
+    const U = [];
+    for (let i = 0; i < n; ++i) {
+        const c = S.charCodeAt(i);
+        if (c < 0xD800 || c > 0xDFFF) {
+            U.push(String.fromCodePoint(c));
+        } else if (0xDC00 <= c && c <= 0xDFFF) {
+            U.push(String.fromCodePoint(0xFFFD));
+        } else {
+            if (i === n - 1) {
+                U.push(String.fromCodePoint(0xFFFD));
+            } else {
+                const d = S.charCodeAt(i + 1);
+                if (0xDC00 <= d && d <= 0xDFFF) {
+                    const a = c & 0x3FF;
+                    const b = d & 0x3FF;
+                    U.push(String.fromCodePoint((2 << 15) + (2 << 9) * a + b));
+                    ++i;
+                } else {
+                    U.push(String.fromCodePoint(0xFFFD));
+                }
+            }
+        }
+    }
+
+    return U.join('');
+};
+
+conversions["Date"] = function (V, opts) {
+    if (!(V instanceof Date)) {
+        throw new TypeError("Argument is not a Date object");
+    }
+    if (isNaN(V)) {
+        return undefined;
+    }
+
+    return V;
+};
+
+conversions["RegExp"] = function (V, opts) {
+    if (!(V instanceof RegExp)) {
+        V = new RegExp(V);
+    }
+
+    return V;
+};
 
 
 /***/ }),
 
-/***/ 5030:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-function getUserAgent() {
-  if (typeof navigator === "object" && "userAgent" in navigator) {
-    return navigator.userAgent;
-  }
-
-  if (typeof process === "object" && "version" in process) {
-    return `Node.js/${process.version.substr(1)} (${process.platform}; ${process.arch})`;
-  }
-
-  return "<environment undetectable>";
-}
-
-exports.getUserAgent = getUserAgent;
-//# sourceMappingURL=index.js.map
-
-
-/***/ }),
-
-/***/ 7537:
+/***/ 8262:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-const usm = __nccwpck_require__(2158);
+const usm = __nccwpck_require__(33);
 
 exports.implementation = class URLImpl {
   constructor(constructorArgs) {
@@ -6727,15 +6569,15 @@ exports.implementation = class URLImpl {
 
 /***/ }),
 
-/***/ 3394:
+/***/ 653:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const conversions = __nccwpck_require__(6059);
-const utils = __nccwpck_require__(3185);
-const Impl = __nccwpck_require__(7537);
+const conversions = __nccwpck_require__(5871);
+const utils = __nccwpck_require__(276);
+const Impl = __nccwpck_require__(8262);
 
 const impl = utils.implSymbol;
 
@@ -6931,32 +6773,32 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8665:
+/***/ 3323:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-exports.URL = __nccwpck_require__(3394).interface;
-exports.serializeURL = __nccwpck_require__(2158).serializeURL;
-exports.serializeURLOrigin = __nccwpck_require__(2158).serializeURLOrigin;
-exports.basicURLParse = __nccwpck_require__(2158).basicURLParse;
-exports.setTheUsername = __nccwpck_require__(2158).setTheUsername;
-exports.setThePassword = __nccwpck_require__(2158).setThePassword;
-exports.serializeHost = __nccwpck_require__(2158).serializeHost;
-exports.serializeInteger = __nccwpck_require__(2158).serializeInteger;
-exports.parseURL = __nccwpck_require__(2158).parseURL;
+exports.URL = __nccwpck_require__(653).interface;
+exports.serializeURL = __nccwpck_require__(33).serializeURL;
+exports.serializeURLOrigin = __nccwpck_require__(33).serializeURLOrigin;
+exports.basicURLParse = __nccwpck_require__(33).basicURLParse;
+exports.setTheUsername = __nccwpck_require__(33).setTheUsername;
+exports.setThePassword = __nccwpck_require__(33).setThePassword;
+exports.serializeHost = __nccwpck_require__(33).serializeHost;
+exports.serializeInteger = __nccwpck_require__(33).serializeInteger;
+exports.parseURL = __nccwpck_require__(33).parseURL;
 
 
 /***/ }),
 
-/***/ 2158:
+/***/ 33:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const punycode = __nccwpck_require__(4213);
-const tr46 = __nccwpck_require__(4256);
+const tr46 = __nccwpck_require__(2299);
 
 const specialSchemes = {
   ftp: 21,
@@ -8255,7 +8097,7 @@ module.exports.parseURL = function (input, options) {
 
 /***/ }),
 
-/***/ 3185:
+/***/ 276:
 /***/ ((module) => {
 
 "use strict";
@@ -8283,199 +8125,357 @@ module.exports.implForWrapper = function (wrapper) {
 
 /***/ }),
 
-/***/ 6059:
-/***/ ((module) => {
+/***/ 1223:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var wrappy = __nccwpck_require__(2940)
+module.exports = wrappy(once)
+module.exports.strict = wrappy(onceStrict)
+
+once.proto = once(function () {
+  Object.defineProperty(Function.prototype, 'once', {
+    value: function () {
+      return once(this)
+    },
+    configurable: true
+  })
+
+  Object.defineProperty(Function.prototype, 'onceStrict', {
+    value: function () {
+      return onceStrict(this)
+    },
+    configurable: true
+  })
+})
+
+function once (fn) {
+  var f = function () {
+    if (f.called) return f.value
+    f.called = true
+    return f.value = fn.apply(this, arguments)
+  }
+  f.called = false
+  return f
+}
+
+function onceStrict (fn) {
+  var f = function () {
+    if (f.called)
+      throw new Error(f.onceError)
+    f.called = true
+    return f.value = fn.apply(this, arguments)
+  }
+  var name = fn.name || 'Function wrapped with `once`'
+  f.onceError = name + " shouldn't be called more than once"
+  f.called = false
+  return f
+}
+
+
+/***/ }),
+
+/***/ 4294:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+module.exports = __nccwpck_require__(4219);
+
+
+/***/ }),
+
+/***/ 4219:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var conversions = {};
-module.exports = conversions;
+var net = __nccwpck_require__(1631);
+var tls = __nccwpck_require__(4016);
+var http = __nccwpck_require__(8605);
+var https = __nccwpck_require__(7211);
+var events = __nccwpck_require__(8614);
+var assert = __nccwpck_require__(2357);
+var util = __nccwpck_require__(1669);
 
-function sign(x) {
-    return x < 0 ? -1 : 1;
+
+exports.httpOverHttp = httpOverHttp;
+exports.httpsOverHttp = httpsOverHttp;
+exports.httpOverHttps = httpOverHttps;
+exports.httpsOverHttps = httpsOverHttps;
+
+
+function httpOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http.request;
+  return agent;
 }
 
-function evenRound(x) {
-    // Round x to the nearest integer, choosing the even integer if it lies halfway between two.
-    if ((x % 1) === 0.5 && (x & 1) === 0) { // [even number].5; round down (i.e. floor)
-        return Math.floor(x);
+function httpsOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http.request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+function httpOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https.request;
+  return agent;
+}
+
+function httpsOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https.request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+
+function TunnelingAgent(options) {
+  var self = this;
+  self.options = options || {};
+  self.proxyOptions = self.options.proxy || {};
+  self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
+  self.requests = [];
+  self.sockets = [];
+
+  self.on('free', function onFree(socket, host, port, localAddress) {
+    var options = toOptions(host, port, localAddress);
+    for (var i = 0, len = self.requests.length; i < len; ++i) {
+      var pending = self.requests[i];
+      if (pending.host === options.host && pending.port === options.port) {
+        // Detect the request to connect same origin server,
+        // reuse the connection.
+        self.requests.splice(i, 1);
+        pending.request.onSocket(socket);
+        return;
+      }
+    }
+    socket.destroy();
+    self.removeSocket(socket);
+  });
+}
+util.inherits(TunnelingAgent, events.EventEmitter);
+
+TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
+  var self = this;
+  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
+
+  if (self.sockets.length >= this.maxSockets) {
+    // We are over limit so we'll add it to the queue.
+    self.requests.push(options);
+    return;
+  }
+
+  // If we are under maxSockets create a new one.
+  self.createSocket(options, function(socket) {
+    socket.on('free', onFree);
+    socket.on('close', onCloseOrRemove);
+    socket.on('agentRemove', onCloseOrRemove);
+    req.onSocket(socket);
+
+    function onFree() {
+      self.emit('free', socket, options);
+    }
+
+    function onCloseOrRemove(err) {
+      self.removeSocket(socket);
+      socket.removeListener('free', onFree);
+      socket.removeListener('close', onCloseOrRemove);
+      socket.removeListener('agentRemove', onCloseOrRemove);
+    }
+  });
+};
+
+TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+  var self = this;
+  var placeholder = {};
+  self.sockets.push(placeholder);
+
+  var connectOptions = mergeOptions({}, self.proxyOptions, {
+    method: 'CONNECT',
+    path: options.host + ':' + options.port,
+    agent: false,
+    headers: {
+      host: options.host + ':' + options.port
+    }
+  });
+  if (options.localAddress) {
+    connectOptions.localAddress = options.localAddress;
+  }
+  if (connectOptions.proxyAuth) {
+    connectOptions.headers = connectOptions.headers || {};
+    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
+        new Buffer(connectOptions.proxyAuth).toString('base64');
+  }
+
+  debug('making CONNECT request');
+  var connectReq = self.request(connectOptions);
+  connectReq.useChunkedEncodingByDefault = false; // for v0.6
+  connectReq.once('response', onResponse); // for v0.6
+  connectReq.once('upgrade', onUpgrade);   // for v0.6
+  connectReq.once('connect', onConnect);   // for v0.7 or later
+  connectReq.once('error', onError);
+  connectReq.end();
+
+  function onResponse(res) {
+    // Very hacky. This is necessary to avoid http-parser leaks.
+    res.upgrade = true;
+  }
+
+  function onUpgrade(res, socket, head) {
+    // Hacky.
+    process.nextTick(function() {
+      onConnect(res, socket, head);
+    });
+  }
+
+  function onConnect(res, socket, head) {
+    connectReq.removeAllListeners();
+    socket.removeAllListeners();
+
+    if (res.statusCode !== 200) {
+      debug('tunneling socket could not be established, statusCode=%d',
+        res.statusCode);
+      socket.destroy();
+      var error = new Error('tunneling socket could not be established, ' +
+        'statusCode=' + res.statusCode);
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    if (head.length > 0) {
+      debug('got illegal response body from proxy');
+      socket.destroy();
+      var error = new Error('got illegal response body from proxy');
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    debug('tunneling connection has established');
+    self.sockets[self.sockets.indexOf(placeholder)] = socket;
+    return cb(socket);
+  }
+
+  function onError(cause) {
+    connectReq.removeAllListeners();
+
+    debug('tunneling socket could not be established, cause=%s\n',
+          cause.message, cause.stack);
+    var error = new Error('tunneling socket could not be established, ' +
+                          'cause=' + cause.message);
+    error.code = 'ECONNRESET';
+    options.request.emit('error', error);
+    self.removeSocket(placeholder);
+  }
+};
+
+TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
+  var pos = this.sockets.indexOf(socket)
+  if (pos === -1) {
+    return;
+  }
+  this.sockets.splice(pos, 1);
+
+  var pending = this.requests.shift();
+  if (pending) {
+    // If we have pending requests and a socket gets closed a new one
+    // needs to be created to take over in the pool for the one that closed.
+    this.createSocket(pending, function(socket) {
+      pending.request.onSocket(socket);
+    });
+  }
+};
+
+function createSecureSocket(options, cb) {
+  var self = this;
+  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
+    var hostHeader = options.request.getHeader('host');
+    var tlsOptions = mergeOptions({}, self.options, {
+      socket: socket,
+      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
+    });
+
+    // 0 is dummy port for v0.6
+    var secureSocket = tls.connect(0, tlsOptions);
+    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+    cb(secureSocket);
+  });
+}
+
+
+function toOptions(host, port, localAddress) {
+  if (typeof host === 'string') { // since v0.10
+    return {
+      host: host,
+      port: port,
+      localAddress: localAddress
+    };
+  }
+  return host; // for v0.11 or later
+}
+
+function mergeOptions(target) {
+  for (var i = 1, len = arguments.length; i < len; ++i) {
+    var overrides = arguments[i];
+    if (typeof overrides === 'object') {
+      var keys = Object.keys(overrides);
+      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
+        var k = keys[j];
+        if (overrides[k] !== undefined) {
+          target[k] = overrides[k];
+        }
+      }
+    }
+  }
+  return target;
+}
+
+
+var debug;
+if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
+  debug = function() {
+    var args = Array.prototype.slice.call(arguments);
+    if (typeof args[0] === 'string') {
+      args[0] = 'TUNNEL: ' + args[0];
     } else {
-        return Math.round(x);
+      args.unshift('TUNNEL:');
     }
+    console.error.apply(console, args);
+  }
+} else {
+  debug = function() {};
+}
+exports.debug = debug; // for test
+
+
+/***/ }),
+
+/***/ 5030:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+function getUserAgent() {
+  if (typeof navigator === "object" && "userAgent" in navigator) {
+    return navigator.userAgent;
+  }
+
+  if (typeof process === "object" && "version" in process) {
+    return `Node.js/${process.version.substr(1)} (${process.platform}; ${process.arch})`;
+  }
+
+  return "<environment undetectable>";
 }
 
-function createNumberConversion(bitLength, typeOpts) {
-    if (!typeOpts.unsigned) {
-        --bitLength;
-    }
-    const lowerBound = typeOpts.unsigned ? 0 : -Math.pow(2, bitLength);
-    const upperBound = Math.pow(2, bitLength) - 1;
-
-    const moduloVal = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength) : Math.pow(2, bitLength);
-    const moduloBound = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength - 1) : Math.pow(2, bitLength - 1);
-
-    return function(V, opts) {
-        if (!opts) opts = {};
-
-        let x = +V;
-
-        if (opts.enforceRange) {
-            if (!Number.isFinite(x)) {
-                throw new TypeError("Argument is not a finite number");
-            }
-
-            x = sign(x) * Math.floor(Math.abs(x));
-            if (x < lowerBound || x > upperBound) {
-                throw new TypeError("Argument is not in byte range");
-            }
-
-            return x;
-        }
-
-        if (!isNaN(x) && opts.clamp) {
-            x = evenRound(x);
-
-            if (x < lowerBound) x = lowerBound;
-            if (x > upperBound) x = upperBound;
-            return x;
-        }
-
-        if (!Number.isFinite(x) || x === 0) {
-            return 0;
-        }
-
-        x = sign(x) * Math.floor(Math.abs(x));
-        x = x % moduloVal;
-
-        if (!typeOpts.unsigned && x >= moduloBound) {
-            return x - moduloVal;
-        } else if (typeOpts.unsigned) {
-            if (x < 0) {
-              x += moduloVal;
-            } else if (x === -0) { // don't return negative zero
-              return 0;
-            }
-        }
-
-        return x;
-    }
-}
-
-conversions["void"] = function () {
-    return undefined;
-};
-
-conversions["boolean"] = function (val) {
-    return !!val;
-};
-
-conversions["byte"] = createNumberConversion(8, { unsigned: false });
-conversions["octet"] = createNumberConversion(8, { unsigned: true });
-
-conversions["short"] = createNumberConversion(16, { unsigned: false });
-conversions["unsigned short"] = createNumberConversion(16, { unsigned: true });
-
-conversions["long"] = createNumberConversion(32, { unsigned: false });
-conversions["unsigned long"] = createNumberConversion(32, { unsigned: true });
-
-conversions["long long"] = createNumberConversion(32, { unsigned: false, moduloBitLength: 64 });
-conversions["unsigned long long"] = createNumberConversion(32, { unsigned: true, moduloBitLength: 64 });
-
-conversions["double"] = function (V) {
-    const x = +V;
-
-    if (!Number.isFinite(x)) {
-        throw new TypeError("Argument is not a finite floating-point value");
-    }
-
-    return x;
-};
-
-conversions["unrestricted double"] = function (V) {
-    const x = +V;
-
-    if (isNaN(x)) {
-        throw new TypeError("Argument is NaN");
-    }
-
-    return x;
-};
-
-// not quite valid, but good enough for JS
-conversions["float"] = conversions["double"];
-conversions["unrestricted float"] = conversions["unrestricted double"];
-
-conversions["DOMString"] = function (V, opts) {
-    if (!opts) opts = {};
-
-    if (opts.treatNullAsEmptyString && V === null) {
-        return "";
-    }
-
-    return String(V);
-};
-
-conversions["ByteString"] = function (V, opts) {
-    const x = String(V);
-    let c = undefined;
-    for (let i = 0; (c = x.codePointAt(i)) !== undefined; ++i) {
-        if (c > 255) {
-            throw new TypeError("Argument is not a valid bytestring");
-        }
-    }
-
-    return x;
-};
-
-conversions["USVString"] = function (V) {
-    const S = String(V);
-    const n = S.length;
-    const U = [];
-    for (let i = 0; i < n; ++i) {
-        const c = S.charCodeAt(i);
-        if (c < 0xD800 || c > 0xDFFF) {
-            U.push(String.fromCodePoint(c));
-        } else if (0xDC00 <= c && c <= 0xDFFF) {
-            U.push(String.fromCodePoint(0xFFFD));
-        } else {
-            if (i === n - 1) {
-                U.push(String.fromCodePoint(0xFFFD));
-            } else {
-                const d = S.charCodeAt(i + 1);
-                if (0xDC00 <= d && d <= 0xDFFF) {
-                    const a = c & 0x3FF;
-                    const b = d & 0x3FF;
-                    U.push(String.fromCodePoint((2 << 15) + (2 << 9) * a + b));
-                    ++i;
-                } else {
-                    U.push(String.fromCodePoint(0xFFFD));
-                }
-            }
-        }
-    }
-
-    return U.join('');
-};
-
-conversions["Date"] = function (V, opts) {
-    if (!(V instanceof Date)) {
-        throw new TypeError("Argument is not a Date object");
-    }
-    if (isNaN(V)) {
-        return undefined;
-    }
-
-    return V;
-};
-
-conversions["RegExp"] = function (V, opts) {
-    if (!(V instanceof RegExp)) {
-        V = new RegExp(V);
-    }
-
-    return V;
-};
+exports.getUserAgent = getUserAgent;
+//# sourceMappingURL=index.js.map
 
 
 /***/ }),
@@ -8895,7 +8895,7 @@ async function main() {
 
     // Add prefix to file name URLs
     const prefixFilenameUrl = core.getInput('prefix-filename-url')
-    
+
     // comment ID to uniquely identify a comment.
     const commentIdentifier = `<!-- codeCoverageDiffComment -->`
 
@@ -8932,7 +8932,7 @@ async function main() {
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber });
-    
+
     // Get coverage details.
     // fullCoverage: This will provide a full coverage report. You can set it to false if you do not need full coverage
     const { decreaseStatusLines, remainingStatusLines, totalCoverageLines } = diffChecker.getCoverageDetails(!fullCoverage)
@@ -8942,11 +8942,13 @@ async function main() {
     let messageToPost = `## Coverage Report \n\n`
 
     messageToPost += `* **Status**: ${isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
+    console.log('messageToPost1!!!', messageToPost.length);
 
     // Add the custom message if it exists
     if (customMessage !== '') {
       messageToPost += `* ${customMessage} \n`;
     }
+    console.log('messageToPost2!!!', messageToPost.length);
 
     // If coverageDetails length is 0 that means there is no change between base and head
     if (remainingStatusLines.length === 0 && decreaseStatusLines.length === 0) {
@@ -8954,17 +8956,20 @@ async function main() {
               '* No changes to code coverage between the master branch and the current head branch'
       messageToPost += '\n--- \n\n'
     } else {
+      console.log('messageToPost3!!!', messageToPost.length);
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {
         messageToPost += `* Current PR reduces the test coverage percentage by ${delta} for some tests \n`
       }
       messageToPost += '--- \n\n'
+      console.log('messageToPost4!!!', messageToPost.length);
       if (decreaseStatusLines.length > 0) {
         messageToPost +=
               'Status | Changes Missing Coverage | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
         messageToPost += decreaseStatusLines.join('\n')
         messageToPost += '\n--- \n\n'
       }
+      console.log('messageToPost5!!!', messageToPost.length);
 
       // Show coverage table for all files that were affected because of this PR
       if (remainingStatusLines.length > 0) {
@@ -8972,10 +8977,12 @@ async function main() {
         messageToPost += '<summary markdown="span">Click to view remaining coverage report</summary>\n\n'
         messageToPost +=
               'Status | File | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
+        console.log('messageToPost6!!!', messageToPost);
         messageToPost += remainingStatusLines.join('\n')
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
+        console.log('messageToPost7!!!', messageToPost.length);
       }
     }
 
@@ -8989,9 +8996,12 @@ async function main() {
       messageToPost +=
             `| Total | ${linesTotalPct}% | \n :-----|-----: \n Change from base: | ${lineChangesPct}% \n Covered Lines: | ${linesCovered} \n Total Lines: | ${linesTotal} \n`;
     }
+    console.log('messageToPost8!!!', messageToPost.length);
 
     messageToPost = `${commentIdentifier} \n ${messageToPost}`
     let commentId = null
+
+    console.log('messageToPost9!!!', messageToPost.length);
 
     // If useSameComment is true, then find the comment and then update that comment.
     // If not, then create a new comment
@@ -9013,7 +9023,7 @@ async function main() {
       messageToPost,
       prNumber
     )
-      
+
     // check if the test coverage is falling below delta/tolerance.
     if (diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
       throw Error(messageToPost)
@@ -9036,7 +9046,7 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
-/***/ 68:
+/***/ 8661:
 /***/ ((module) => {
 
 "use strict";

--- a/dest/index.js
+++ b/dest/index.js
@@ -8556,7 +8556,7 @@ class DiffChecker {
     this.prNumber = prNumber;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]).map
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**
      * For all filePaths in coverage, generate a percentage value

--- a/dest/index.js
+++ b/dest/index.js
@@ -8925,6 +8925,9 @@ async function main() {
     const coverageReportNew = JSON.parse(external_fs_default().readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(external_fs_default().readFileSync(baseCoverageReportPath).toString());
 
+    console.log('[ coverageReportOld ] >', coverageReportOld.length);
+    console.log('[ coverageReportNew ] >', coverageReportNew.length);
+
     // Get the current directory to replace the file name paths
     const currentDirectory = (0,external_child_process_namespaceObject.execSync)('pwd')
       .toString()
@@ -8982,7 +8985,7 @@ async function main() {
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
-        console.log('messageToPost7!!!', messageToPost);
+        console.log('messageToPost7!!!', messageToPost.length);
       }
     }
 

--- a/dest/index.js
+++ b/dest/index.js
@@ -8539,13 +8539,14 @@ const removedCoverageIcon = ':yellow_circle:'
  */
 class DiffChecker {
   constructor({
+    changedFiles,
     coverageReportNew,
     coverageReportOld,
-    delta,
-    changedFiles,
     currentDirectory,
+    delta,
     prefixFilenameUrl,
-    prNumber
+    prNumber,
+    repoName,
   }) {
     this.diffCoverageReport = {};
     this.delta = delta;
@@ -8554,8 +8555,8 @@ class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
-    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split('www').pop());
-    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split('www').pop());
+    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split(repoName).pop());
+    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split(repoName).pop());
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**
@@ -8933,7 +8934,16 @@ async function main() {
       .trim()
 
     // Perform analysis
-    const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber });
+    const diffChecker = new DiffChecker({
+      currentDirectory,
+      changedFiles,
+      coverageReportNew,
+      coverageReportOld,
+      delta,
+      prefixFilenameUrl,
+      prNumber,
+      repoName,
+    });
 
     // Get coverage details.
     // fullCoverage: This will provide a full coverage report. You can set it to false if you do not need full coverage

--- a/dest/index.js
+++ b/dest/index.js
@@ -8554,17 +8554,18 @@ class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
-    const reportNewKeys = Object.keys(coverageReportNew)
-    const reportOldKeys = Object.keys(coverageReportOld)
-    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
+    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split('www').pop());
+    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split('www').pop());
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**
      * For all filePaths in coverage, generate a percentage value
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
-      const newCoverage = this.getFileCoverage(coverageReportNew, filePath);
-      const oldCoverage = this.getFileCoverage(coverageReportOld, filePath);
+      console.log('[ filePath ] >', filePath);
+      const newCoverage = coverageReportNew[filePath];
+      const oldCoverage = coverageReportOld[filePath];
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage ? oldCoverage.branches : null,
@@ -8789,12 +8790,6 @@ class DiffChecker {
     const diff = Number(diffData.newPct) - Number(diffData.oldPct)
     // round off the diff to 2 decimal places
     return Math.round((diff + Number.EPSILON) * 100) / 100
-  }
-
-  getFileCoverage(report, filePath) {
-    if (report[filePath]) return report[filePath];
-
-    return report[filePath.replace('/runner/_work', '/home/runner/work')];
   }
 }
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js

--- a/dest/index.js
+++ b/dest/index.js
@@ -8603,8 +8603,8 @@ class DiffChecker {
 
   /**
    * Create coverageDetails table
-   * @param {*} diffOnly 
-   * @returns 
+   * @param {*} diffOnly
+   * @returns
    */
   getCoverageDetails(diffOnly) {
     const keys = Object.keys(this.diffCoverageReport)
@@ -8653,8 +8653,8 @@ class DiffChecker {
 
   /**
    * Function to check if the file's coverage is below delta
-   * @param {*} delta 
-   * @returns 
+   * @param {*} delta
+   * @returns
    */
   checkIfTestCoverageFallsBelowDelta(delta) {
     const keys = Object.keys(this.diffCoverageReport)
@@ -8671,7 +8671,7 @@ class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          if (-this.getPercentageDiff(diffCoverageData[key]) > delta 
+          if (-this.getPercentageDiff(diffCoverageData[key]) > delta
             && !this.isDueToRemovedLines(diffCoverageData[key])) {
             // Check only changed files
             if (this.checkOnlyChangedFiles(fileName)) {
@@ -8690,15 +8690,15 @@ class DiffChecker {
     const oldCoverage = diffCoverageData.old;
     if (!oldCoverage || !newCoverage) return false;
 
-    return newCoverage.covered - oldCoverage.covered < 0 && 
+    return newCoverage.covered - oldCoverage.covered < 0 &&
       (oldCoverage.covered - newCoverage.covered === oldCoverage.total - newCoverage.total)
   }
 
   /**
    * Create the table row for the file with higher/lower coverage compared to base branch
-   * @param {*} name 
-   * @param {*} diffFileCoverageData 
-   * @returns 
+   * @param {*} name
+   * @param {*} diffFileCoverageData
+   * @returns
    */
   createDiffLine(
     name,
@@ -8708,6 +8708,9 @@ class DiffChecker {
     const fileNewCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.oldPct === 0
     )
+    if (fileNewCoverage) {
+      console.log('[ fileNewCoverage name ] >', name)
+    }
     // No new coverage found so that means we deleted a file coverage
     const fileRemovedCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.newPct === 0
@@ -8759,8 +8762,8 @@ class DiffChecker {
 
   /**
    * Show red/green status icon for each file
-   * @param {*} diffFileCoverageData 
-   * @returns 
+   * @param {*} diffFileCoverageData
+   * @returns
    */
   getStatusIcon(
     diffFileCoverageData
@@ -8780,8 +8783,8 @@ class DiffChecker {
 
   /**
    * Get % diff for base vs current branch
-   * @param {*} diffData 
-   * @returns 
+   * @param {*} diffData
+   * @returns
    */
   getPercentageDiff(diffData) {
     const diff = Number(diffData.newPct) - Number(diffData.oldPct)

--- a/dest/index.js
+++ b/dest/index.js
@@ -8608,8 +8608,6 @@ class DiffChecker {
 
   /**
    * Create coverageDetails table
-   * @param {*} diffOnly
-   * @returns
    */
   getCoverageDetails(diffOnly) {
     const keys = Object.keys(this.diffCoverageReport)

--- a/dest/index.js
+++ b/dest/index.js
@@ -8555,8 +8555,10 @@ class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
-    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split(repoName).pop());
-    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split(repoName).pop());
+
+    const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
+    const reportNewKeys = Object.keys(coverageReportNew).map(getRelativePath);
+    const reportOldKeys = Object.keys(coverageReportOld).map(getRelativePath);
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**
@@ -8564,32 +8566,32 @@ class DiffChecker {
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
-      const newCoverage = coverageReportNew[filePath];
-      const oldCoverage = coverageReportOld[filePath];
+      const newCoverage = coverageReportNew[filePath] || {};
+      const oldCoverage = coverageReportOld[filePath] || {};
       this.diffCoverageReport[filePath] = {
         branches: {
-          new: newCoverage ? oldCoverage.branches : null,
-          old: oldCoverage ? oldCoverage.branches : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.branches : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.branches : null)
+          new: newCoverage.branches,
+          old: oldCoverage.branches,
+          newPct: this.getPercentage(newCoverage.branches),
+          oldPct: this.getPercentage(oldCoverage.branches),
         },
         statements: {
-          new: newCoverage ? newCoverage.statements : null,
-          old: oldCoverage ? oldCoverage.statements : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.statements : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.statements : null)
+          new: newCoverage.statements,
+          old:oldCoverage.statements,
+          newPct: this.getPercentage(newCoverage.statements),
+          oldPct: this.getPercentage(oldCoverage.statements),
         },
         lines: {
-          new: newCoverage ? newCoverage.lines : null,
-          old: oldCoverage ? oldCoverage.lines : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.lines : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.lines : null)
+          new: newCoverage.lines,
+          old: oldCoverage.lines,
+          newPct: this.getPercentage(newCoverage.lines),
+          oldPct: this.getPercentage(oldCoverage.lines),
         },
         functions: {
-          new: newCoverage ? newCoverage.functions : null,
-          old: oldCoverage ? oldCoverage.functions : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.functions : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.functions : null)
+          new: newCoverage.functions,
+          old: oldCoverage.functions,
+          newPct: this.getPercentage(newCoverage.functions),
+          oldPct: this.getPercentage(oldCoverage.functions),
         }
       }
     }
@@ -8693,15 +8695,12 @@ class DiffChecker {
     const oldCoverage = diffCoverageData.old;
     if (!oldCoverage || !newCoverage) return false;
 
-    return newCoverage.covered - oldCoverage.covered < 0 &&
+    return newCoverage.covered < oldCoverage.covered &&
       (oldCoverage.covered - newCoverage.covered === oldCoverage.total - newCoverage.total)
   }
 
   /**
    * Create the table row for the file with higher/lower coverage compared to base branch
-   * @param {*} name
-   * @param {*} diffFileCoverageData
-   * @returns
    */
   createDiffLine(
     name,
@@ -8935,10 +8934,10 @@ async function main() {
 
     // Perform analysis
     const diffChecker = new DiffChecker({
-      currentDirectory,
       changedFiles,
       coverageReportNew,
       coverageReportOld,
+      currentDirectory,
       delta,
       prefixFilenameUrl,
       prNumber,
@@ -9004,7 +9003,6 @@ async function main() {
 
     messageToPost = `${commentIdentifier} \n ${messageToPost}`
     let commentId = null
-
 
     // If useSameComment is true, then find the comment and then update that comment.
     // If not, then create a new comment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-cov-reporter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Produce a coverage report and provide a diff with base report",
   "main": "dest/index.js",
   "scripts": {

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -23,8 +23,10 @@ export class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
-    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split(repoName).pop());
-    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split(repoName).pop());
+
+    const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
+    const reportNewKeys = Object.keys(coverageReportNew).map(getRelativePath);
+    const reportOldKeys = Object.keys(coverageReportOld).map(getRelativePath);
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**
@@ -32,32 +34,32 @@ export class DiffChecker {
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
-      const newCoverage = coverageReportNew[filePath];
-      const oldCoverage = coverageReportOld[filePath];
+      const newCoverage = coverageReportNew[filePath] || {};
+      const oldCoverage = coverageReportOld[filePath] || {};
       this.diffCoverageReport[filePath] = {
         branches: {
-          new: newCoverage ? oldCoverage.branches : null,
-          old: oldCoverage ? oldCoverage.branches : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.branches : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.branches : null)
+          new: newCoverage.branches,
+          old: oldCoverage.branches,
+          newPct: this.getPercentage(newCoverage.branches),
+          oldPct: this.getPercentage(oldCoverage.branches),
         },
         statements: {
-          new: newCoverage ? newCoverage.statements : null,
-          old: oldCoverage ? oldCoverage.statements : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.statements : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.statements : null)
+          new: newCoverage.statements,
+          old:oldCoverage.statements,
+          newPct: this.getPercentage(newCoverage.statements),
+          oldPct: this.getPercentage(oldCoverage.statements),
         },
         lines: {
-          new: newCoverage ? newCoverage.lines : null,
-          old: oldCoverage ? oldCoverage.lines : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.lines : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.lines : null)
+          new: newCoverage.lines,
+          old: oldCoverage.lines,
+          newPct: this.getPercentage(newCoverage.lines),
+          oldPct: this.getPercentage(oldCoverage.lines),
         },
         functions: {
-          new: newCoverage ? newCoverage.functions : null,
-          old: oldCoverage ? oldCoverage.functions : null,
-          newPct: this.getPercentage(newCoverage ? newCoverage.functions : null),
-          oldPct: this.getPercentage(oldCoverage ? oldCoverage.functions : null)
+          new: newCoverage.functions,
+          old: oldCoverage.functions,
+          newPct: this.getPercentage(newCoverage.functions),
+          oldPct: this.getPercentage(oldCoverage.functions),
         }
       }
     }
@@ -161,15 +163,12 @@ export class DiffChecker {
     const oldCoverage = diffCoverageData.old;
     if (!oldCoverage || !newCoverage) return false;
 
-    return newCoverage.covered - oldCoverage.covered < 0 &&
+    return newCoverage.covered < oldCoverage.covered &&
       (oldCoverage.covered - newCoverage.covered === oldCoverage.total - newCoverage.total)
   }
 
   /**
    * Create the table row for the file with higher/lower coverage compared to base branch
-   * @param {*} name
-   * @param {*} diffFileCoverageData
-   * @returns
    */
   createDiffLine(
     name,

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -31,7 +31,6 @@ export class DiffChecker {
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
-      console.log('[ filePath ] >', filePath);
       const newCoverage = coverageReportNew[filePath];
       const oldCoverage = coverageReportOld[filePath];
       this.diffCoverageReport[filePath] = {

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -71,8 +71,8 @@ export class DiffChecker {
 
   /**
    * Create coverageDetails table
-   * @param {*} diffOnly 
-   * @returns 
+   * @param {*} diffOnly
+   * @returns
    */
   getCoverageDetails(diffOnly) {
     const keys = Object.keys(this.diffCoverageReport)
@@ -121,8 +121,8 @@ export class DiffChecker {
 
   /**
    * Function to check if the file's coverage is below delta
-   * @param {*} delta 
-   * @returns 
+   * @param {*} delta
+   * @returns
    */
   checkIfTestCoverageFallsBelowDelta(delta) {
     const keys = Object.keys(this.diffCoverageReport)
@@ -139,7 +139,7 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          if (-this.getPercentageDiff(diffCoverageData[key]) > delta 
+          if (-this.getPercentageDiff(diffCoverageData[key]) > delta
             && !this.isDueToRemovedLines(diffCoverageData[key])) {
             // Check only changed files
             if (this.checkOnlyChangedFiles(fileName)) {
@@ -158,15 +158,15 @@ export class DiffChecker {
     const oldCoverage = diffCoverageData.old;
     if (!oldCoverage || !newCoverage) return false;
 
-    return newCoverage.covered - oldCoverage.covered < 0 && 
+    return newCoverage.covered - oldCoverage.covered < 0 &&
       (oldCoverage.covered - newCoverage.covered === oldCoverage.total - newCoverage.total)
   }
 
   /**
    * Create the table row for the file with higher/lower coverage compared to base branch
-   * @param {*} name 
-   * @param {*} diffFileCoverageData 
-   * @returns 
+   * @param {*} name
+   * @param {*} diffFileCoverageData
+   * @returns
    */
   createDiffLine(
     name,
@@ -176,6 +176,9 @@ export class DiffChecker {
     const fileNewCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.oldPct === 0
     )
+    if (fileNewCoverage) {
+      console.log('[ fileNewCoverage name ] >', name)
+    }
     // No new coverage found so that means we deleted a file coverage
     const fileRemovedCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.newPct === 0
@@ -227,8 +230,8 @@ export class DiffChecker {
 
   /**
    * Show red/green status icon for each file
-   * @param {*} diffFileCoverageData 
-   * @returns 
+   * @param {*} diffFileCoverageData
+   * @returns
    */
   getStatusIcon(
     diffFileCoverageData
@@ -248,8 +251,8 @@ export class DiffChecker {
 
   /**
    * Get % diff for base vs current branch
-   * @param {*} diffData 
-   * @returns 
+   * @param {*} diffData
+   * @returns
    */
   getPercentageDiff(diffData) {
     const diff = Number(diffData.newPct) - Number(diffData.oldPct)

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -22,17 +22,18 @@ export class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
-    const reportNewKeys = Object.keys(coverageReportNew)
-    const reportOldKeys = Object.keys(coverageReportOld)
-    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
+    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split('www').pop());
+    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split('www').pop());
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**
      * For all filePaths in coverage, generate a percentage value
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
-      const newCoverage = this.getFileCoverage(coverageReportNew, filePath);
-      const oldCoverage = this.getFileCoverage(coverageReportOld, filePath);
+      console.log('[ filePath ] >', filePath);
+      const newCoverage = coverageReportNew[filePath];
+      const oldCoverage = coverageReportOld[filePath];
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage ? oldCoverage.branches : null,
@@ -257,11 +258,5 @@ export class DiffChecker {
     const diff = Number(diffData.newPct) - Number(diffData.oldPct)
     // round off the diff to 2 decimal places
     return Math.round((diff + Number.EPSILON) * 100) / 100
-  }
-
-  getFileCoverage(report, filePath) {
-    if (report[filePath]) return report[filePath];
-
-    return report[filePath.replace('/runner/_work', '/home/runner/work')];
   }
 }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -31,30 +31,32 @@ export class DiffChecker {
      * for both base and current branch
      */
     for (const filePath of reportKeys) {
+      const newCoverage = this.getFileCoverage(coverageReportNew, filePath);
+      const oldCoverage = this.getFileCoverage(coverageReportOld, filePath);
       this.diffCoverageReport[filePath] = {
         branches: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].branches : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].branches : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].branches : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].branches : null)
+          new: newCoverage ? oldCoverage.branches : null,
+          old: oldCoverage ? oldCoverage.branches : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.branches : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.branches : null)
         },
         statements: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].statements : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].statements : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].statements : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].statements : null)
+          new: newCoverage ? newCoverage.statements : null,
+          old: oldCoverage ? oldCoverage.statements : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.statements : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.statements : null)
         },
         lines: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].lines : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].lines : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].lines : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].lines : null)
+          new: newCoverage ? newCoverage.lines : null,
+          old: oldCoverage ? oldCoverage.lines : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.lines : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.lines : null)
         },
         functions: {
-          new: coverageReportNew[filePath] ? coverageReportNew[filePath].functions : null,
-          old: coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null,
-          newPct: this.getPercentage(coverageReportNew[filePath] ? coverageReportNew[filePath].functions : null),
-          oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null)
+          new: newCoverage ? newCoverage.functions : null,
+          old: oldCoverage ? oldCoverage.functions : null,
+          newPct: this.getPercentage(newCoverage ? newCoverage.functions : null),
+          oldPct: this.getPercentage(oldCoverage ? oldCoverage.functions : null)
         }
       }
     }
@@ -260,6 +262,6 @@ export class DiffChecker {
   getFileCoverage(report, filePath) {
     if (report[filePath]) return report[filePath];
 
-    return report[filePath.replace('/runner/_work', '/runner/work')];
+    return report[filePath.replace('/runner/_work', '/home/runner/work')];
   }
 }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -24,7 +24,7 @@ export class DiffChecker {
     this.prNumber = prNumber;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]).map
 
     /**
      * For all filePaths in coverage, generate a percentage value
@@ -57,7 +57,6 @@ export class DiffChecker {
           oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null)
         }
       }
-      console.log('[ this.diffCoverageReport ] >', this.diffCoverageReport)
     }
   }
 
@@ -177,9 +176,6 @@ export class DiffChecker {
     const fileNewCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.oldPct === 0
     )
-    if (fileNewCoverage) {
-      console.log('[ fileNewCoverage name ] >', name)
-    }
     // No new coverage found so that means we deleted a file coverage
     const fileRemovedCoverage = Object.values(diffFileCoverageData).every(
       coverageData => coverageData.newPct === 0
@@ -259,5 +255,11 @@ export class DiffChecker {
     const diff = Number(diffData.newPct) - Number(diffData.oldPct)
     // round off the diff to 2 decimal places
     return Math.round((diff + Number.EPSILON) * 100) / 100
+  }
+
+  getFileCoverage(report, filePath) {
+    if (report[filePath]) return report[filePath];
+
+    return report[filePath.replace('/runner/_work', '/runner/work')];
   }
 }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -7,13 +7,14 @@ const removedCoverageIcon = ':yellow_circle:'
  */
 export class DiffChecker {
   constructor({
+    changedFiles,
     coverageReportNew,
     coverageReportOld,
-    delta,
-    changedFiles,
     currentDirectory,
+    delta,
     prefixFilenameUrl,
-    prNumber
+    prNumber,
+    repoName,
   }) {
     this.diffCoverageReport = {};
     this.delta = delta;
@@ -22,8 +23,8 @@ export class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
-    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split('www').pop());
-    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split('www').pop());
+    const reportNewKeys = Object.keys(coverageReportNew).map((key) => key.split(repoName).pop());
+    const reportOldKeys = Object.keys(coverageReportOld).map((key) => key.split(repoName).pop());
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -57,6 +57,7 @@ export class DiffChecker {
           oldPct: this.getPercentage(coverageReportOld[filePath] ? coverageReportOld[filePath].functions : null)
         }
       }
+      console.log('[ this.diffCoverageReport ] >', this.diffCoverageReport)
     }
   }
 

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -24,7 +24,7 @@ export class DiffChecker {
     this.prNumber = prNumber;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]).map
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**
      * For all filePaths in coverage, generate a percentage value

--- a/src/index.js
+++ b/src/index.js
@@ -61,9 +61,6 @@ async function main() {
     const coverageReportNew = JSON.parse(fs.readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(fs.readFileSync(baseCoverageReportPath).toString());
 
-    console.log('[ coverageReportOld ] >', coverageReportOld);
-    console.log('[ coverageReportNew ] >', coverageReportNew);
-
     // Get the current directory to replace the file name paths
     const currentDirectory = execSync('pwd')
       .toString()

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,8 @@ async function main() {
     const coverageReportNew = JSON.parse(fs.readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(fs.readFileSync(baseCoverageReportPath).toString());
 
-    // console.log('[ coverageReportOld ] >', coverageReportOld);
-    // console.log('[ coverageReportNew ] >', coverageReportNew);
+    console.log('[ coverageReportOld ] >', coverageReportOld);
+    console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = execSync('pwd')
@@ -81,13 +81,11 @@ async function main() {
     let messageToPost = `## Coverage Report \n\n`
 
     messageToPost += `* **Status**: ${isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
-    console.log('messageToPost1!!!', messageToPost.length);
 
     // Add the custom message if it exists
     if (customMessage !== '') {
       messageToPost += `* ${customMessage} \n`;
     }
-    console.log('messageToPost2!!!', messageToPost.length);
 
     // If coverageDetails length is 0 that means there is no change between base and head
     if (remainingStatusLines.length === 0 && decreaseStatusLines.length === 0) {
@@ -95,20 +93,17 @@ async function main() {
               '* No changes to code coverage between the master branch and the current head branch'
       messageToPost += '\n--- \n\n'
     } else {
-      console.log('messageToPost3!!!', messageToPost.length);
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {
         messageToPost += `* Current PR reduces the test coverage percentage by ${delta} for some tests \n`
       }
       messageToPost += '--- \n\n'
-      console.log('messageToPost4!!!', messageToPost.length);
       if (decreaseStatusLines.length > 0) {
         messageToPost +=
               'Status | Changes Missing Coverage | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
         messageToPost += decreaseStatusLines.join('\n')
         messageToPost += '\n--- \n\n'
       }
-      console.log('messageToPost5!!!', messageToPost.length);
 
       // Show coverage table for all files that were affected because of this PR
       if (remainingStatusLines.length > 0) {
@@ -116,12 +111,10 @@ async function main() {
         messageToPost += '<summary markdown="span">Click to view remaining coverage report</summary>\n\n'
         messageToPost +=
               'Status | File | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
-        console.log('messageToPost6!!!', messageToPost.length);
         messageToPost += remainingStatusLines.join('\n')
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
-        console.log('messageToPost7!!!', messageToPost.length);
       }
     }
 
@@ -135,12 +128,10 @@ async function main() {
       messageToPost +=
             `| Total | ${linesTotalPct}% | \n :-----|-----: \n Change from base: | ${lineChangesPct}% \n Covered Lines: | ${linesCovered} \n Total Lines: | ${linesTotal} \n`;
     }
-    console.log('messageToPost8!!!', messageToPost.length);
 
     messageToPost = `${commentIdentifier} \n ${messageToPost}`
     let commentId = null
 
-    console.log('messageToPost9!!!', messageToPost.length);
 
     // If useSameComment is true, then find the comment and then update that comment.
     // If not, then create a new comment

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,16 @@ async function main() {
       .trim()
 
     // Perform analysis
-    const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber });
+    const diffChecker = new DiffChecker({
+      currentDirectory,
+      changedFiles,
+      coverageReportNew,
+      coverageReportOld,
+      delta,
+      prefixFilenameUrl,
+      prNumber,
+      repoName,
+    });
 
     // Get coverage details.
     // fullCoverage: This will provide a full coverage report. You can set it to false if you do not need full coverage

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,8 @@ async function main() {
     const coverageReportNew = JSON.parse(fs.readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(fs.readFileSync(baseCoverageReportPath).toString());
 
-    console.log('[ coverageReportOld ] >', coverageReportOld);
-    console.log('[ coverageReportNew ] >', coverageReportNew);
+    // console.log('[ coverageReportOld ] >', coverageReportOld);
+    // console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = execSync('pwd')

--- a/src/index.js
+++ b/src/index.js
@@ -68,10 +68,10 @@ async function main() {
 
     // Perform analysis
     const diffChecker = new DiffChecker({
-      currentDirectory,
       changedFiles,
       coverageReportNew,
       coverageReportOld,
+      currentDirectory,
       delta,
       prefixFilenameUrl,
       prNumber,
@@ -137,7 +137,6 @@ async function main() {
 
     messageToPost = `${commentIdentifier} \n ${messageToPost}`
     let commentId = null
-
 
     // If useSameComment is true, then find the comment and then update that comment.
     // If not, then create a new comment

--- a/src/index.js
+++ b/src/index.js
@@ -113,12 +113,12 @@ async function main() {
         messageToPost += '<summary markdown="span">Click to view remaining coverage report</summary>\n\n'
         messageToPost +=
               'Status | File | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
-        console.log('messageToPost6!!!', messageToPost);
+        console.log('messageToPost6!!!', messageToPost.length);
         messageToPost += remainingStatusLines.join('\n')
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
-        console.log('messageToPost7!!!', messageToPost.length);
+        console.log('messageToPost7!!!', messageToPost);
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ async function main() {
 
     // Add prefix to file name URLs
     const prefixFilenameUrl = core.getInput('prefix-filename-url')
-    
+
     // comment ID to uniquely identify a comment.
     const commentIdentifier = `<!-- codeCoverageDiffComment -->`
 
@@ -68,7 +68,7 @@ async function main() {
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber });
-    
+
     // Get coverage details.
     // fullCoverage: This will provide a full coverage report. You can set it to false if you do not need full coverage
     const { decreaseStatusLines, remainingStatusLines, totalCoverageLines } = diffChecker.getCoverageDetails(!fullCoverage)
@@ -78,11 +78,13 @@ async function main() {
     let messageToPost = `## Coverage Report \n\n`
 
     messageToPost += `* **Status**: ${isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
+    console.log('messageToPost1!!!', messageToPost.length);
 
     // Add the custom message if it exists
     if (customMessage !== '') {
       messageToPost += `* ${customMessage} \n`;
     }
+    console.log('messageToPost2!!!', messageToPost.length);
 
     // If coverageDetails length is 0 that means there is no change between base and head
     if (remainingStatusLines.length === 0 && decreaseStatusLines.length === 0) {
@@ -90,17 +92,20 @@ async function main() {
               '* No changes to code coverage between the master branch and the current head branch'
       messageToPost += '\n--- \n\n'
     } else {
+      console.log('messageToPost3!!!', messageToPost.length);
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {
         messageToPost += `* Current PR reduces the test coverage percentage by ${delta} for some tests \n`
       }
       messageToPost += '--- \n\n'
+      console.log('messageToPost4!!!', messageToPost.length);
       if (decreaseStatusLines.length > 0) {
         messageToPost +=
               'Status | Changes Missing Coverage | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
         messageToPost += decreaseStatusLines.join('\n')
         messageToPost += '\n--- \n\n'
       }
+      console.log('messageToPost5!!!', messageToPost.length);
 
       // Show coverage table for all files that were affected because of this PR
       if (remainingStatusLines.length > 0) {
@@ -108,10 +113,12 @@ async function main() {
         messageToPost += '<summary markdown="span">Click to view remaining coverage report</summary>\n\n'
         messageToPost +=
               'Status | File | Stmts | Branch | Funcs | Lines \n -----|-----|---------|----------|---------|------ \n'
+        console.log('messageToPost6!!!', messageToPost);
         messageToPost += remainingStatusLines.join('\n')
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
+        console.log('messageToPost7!!!', messageToPost.length);
       }
     }
 
@@ -125,9 +132,12 @@ async function main() {
       messageToPost +=
             `| Total | ${linesTotalPct}% | \n :-----|-----: \n Change from base: | ${lineChangesPct}% \n Covered Lines: | ${linesCovered} \n Total Lines: | ${linesTotal} \n`;
     }
+    console.log('messageToPost8!!!', messageToPost.length);
 
     messageToPost = `${commentIdentifier} \n ${messageToPost}`
     let commentId = null
+
+    console.log('messageToPost9!!!', messageToPost.length);
 
     // If useSameComment is true, then find the comment and then update that comment.
     // If not, then create a new comment
@@ -149,7 +159,7 @@ async function main() {
       messageToPost,
       prNumber
     )
-      
+
     // check if the test coverage is falling below delta/tolerance.
     if (diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
       throw Error(messageToPost)

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,8 @@ async function main() {
     const coverageReportNew = JSON.parse(fs.readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(fs.readFileSync(baseCoverageReportPath).toString());
 
-    console.log('[ coverageReportOld ] >', coverageReportOld.length);
-    console.log('[ coverageReportNew ] >', coverageReportNew.length);
+    console.log('[ coverageReportOld ] >', coverageReportOld);
+    console.log('[ coverageReportNew ] >', coverageReportNew);
 
     // Get the current directory to replace the file name paths
     const currentDirectory = execSync('pwd')

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,9 @@ async function main() {
     const coverageReportNew = JSON.parse(fs.readFileSync(branchCoverageReportPath).toString());
     const coverageReportOld = JSON.parse(fs.readFileSync(baseCoverageReportPath).toString());
 
+    console.log('[ coverageReportOld ] >', coverageReportOld.length);
+    console.log('[ coverageReportNew ] >', coverageReportNew.length);
+
     // Get the current directory to replace the file name paths
     const currentDirectory = execSync('pwd')
       .toString()
@@ -118,7 +121,7 @@ async function main() {
         messageToPost += '\n';
         messageToPost += '</details>';
         messageToPost += '\n\n--- \n\n'
-        console.log('messageToPost7!!!', messageToPost);
+        console.log('messageToPost7!!!', messageToPost.length);
       }
     }
 


### PR DESCRIPTION
## Which problem does this PR solve?

When migrating to self-hosted runner, there is an [error](https://github.com/adRise/www/runs/6088028483?check_suite_focus=true) thrown by jest-cov-reporter  `Body is too long (maximum is 65536 characters)`.

![image](https://user-images.githubusercontent.com/4938243/164316081-0bce84ec-3b03-4269-b237-391780157543.png)

After some debugging, I found the root cause is the repo path is different. Take one file for example:
- GitHub runner: `/runner/_work/www/www/packages/analytics/src/baseTypes.ts`
- Self-hosted runner: `/home/runner/work/www/www/packages/analytics/src/baseTypes.ts`

So when we use it as the file path and try comparing the old report and the new report, it always finds another report missing and creates a new item, which leads to a huge comment. 

## Main changes

When generating the keys (paths), only use the relative path. For example:
- before: `/runner/_work/www/www/packages/analytics/src/baseTypes.ts`
- after: `/packages/analytics/src/baseTypes.ts`

##  How I tested it works

Tested it's working now https://github.com/adRise/www/runs/6102096356?check_suite_focus=true