### PR TITLE
We need always have 100 coverage for new files added

### DIFF
--- a/dest/index.js
+++ b/dest/index.js
@@ -8910,6 +8910,7 @@ async function main() {
     const repoName = github.context.repo.repo
     // get the repo owner
     const repoOwner = github.context.repo.owner
+    
     // github token
     const githubToken = core.getInput('accessToken')
     // Full coverage (true/false)
@@ -8965,13 +8966,13 @@ async function main() {
       .toString()
       .trim()
 
-    const labels = await githubClient.pulls.labels({
+    const pullRequest = await githubClient.pulls.get({
       owner: repoOwner,
       repo: repoName,
       pull_number: prNumber,
     });
 
-    const checkNewFileFullCoverage = !labels.some(label => label.name.includes('skip-new-file-full-coverage'));
+    const checkNewFileFullCoverage = !pullRequest.data.labels?.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/dest/index.js
+++ b/dest/index.js
@@ -8614,7 +8614,7 @@ class DiffChecker {
     const decreaseStatusLines = [];
     const remainingStatusLines = [];
     for (const key of keys) {
-      if (this.compareCoverageValues(key, this.diffCoverageReport[key]) !== 0) {
+      if (this.compareCoverageValues(key) !== 0) {
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -8778,10 +8778,9 @@ class DiffChecker {
   }
 
   compareCoverageValues(
-    file,
-    diffCoverageData
+    file
   ) {
-    const values = Object.values(diffCoverageData);
+    const values = Object.values(this.diffCoverageReport[file]);
     const noOldCoverage = values.every((part) => part.oldPct === 0);
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);

--- a/dest/index.js
+++ b/dest/index.js
@@ -8699,6 +8699,7 @@ class DiffChecker {
       const coverageParts = Object.values(diffCoverageData);
       // No old coverage found so that means we added a new file coverage
       const isFileNew = coverageParts.every((coverageData) => coverageData.oldPct === 0);
+      console.log(key, isFileNew, this.checkIfNewFileAllPartsNotFullCoverage(coverageParts), this.checkOnlyChangedFiles(key))
       return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage(coverageParts) && this.checkOnlyChangedFiles(key);
     });
   }

--- a/dest/index.js
+++ b/dest/index.js
@@ -8694,6 +8694,7 @@ class DiffChecker {
   checkIfNewFileNotFullCoverage() {
     if (!this.checkNewFileFullCoverage) return false
     const keys = Object.keys(this.diffCoverageReport);
+    console.log(keys)
     return keys.some((key) => {
       const diffCoverageData = this.diffCoverageReport[key];
       const coverageParts = Object.values(diffCoverageData);
@@ -8710,6 +8711,7 @@ class DiffChecker {
    * @param  {} {return boolen}
    */
   checkIfNewFileAllPartsNotFullCoverage(coverageParts) {
+    console.log(coverageParts)
     return coverageParts.some((coverageData) => coverageData.newPct < 100);
   }
 
@@ -8972,8 +8974,9 @@ async function main() {
       pull_number: prNumber,
     });
 
-    console.log(pullRequest.data.labels, pullRequest.data.labels.some, 'some')
+    console.log(Array.prototype.some)
     const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
+    console.log(checkNewFileFullCoverage)
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/dest/index.js
+++ b/dest/index.js
@@ -8559,6 +8559,7 @@ class DiffChecker {
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
+    console.log(reportNewKeys, reportOldKeys)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**

--- a/dest/index.js
+++ b/dest/index.js
@@ -8570,6 +8570,7 @@ class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
+      console.log(filePath)
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,

--- a/dest/index.js
+++ b/dest/index.js
@@ -8972,7 +8972,7 @@ async function main() {
       pull_number: prNumber,
     });
 
-    console.log(pullRequest.data)
+    console.log(pullRequest.data.labels, pullRequest.data.labels.some, 'some')
     const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
 
     // Perform analysis

--- a/dest/index.js
+++ b/dest/index.js
@@ -8972,7 +8972,7 @@ async function main() {
       pull_number: prNumber,
     });
 
-    const checkNewFileFullCoverage = !pullRequest.data.labels?.some(label => label.name.includes('skip-new-file-full-coverage'));
+    const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/dest/index.js
+++ b/dest/index.js
@@ -8559,7 +8559,8 @@ class DiffChecker {
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    console.log(reportNewKeys, reportOldKeys)
+    reportNewKeys.forEach(v => console.log('new>>>' + v))
+    reportOldKeys.forEach(v => console.log('old>>>' + v))
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**

--- a/dest/index.js
+++ b/dest/index.js
@@ -8973,7 +8973,7 @@ async function main() {
     });
 
     console.log(pullRequest.data)
-    const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
+    const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/dest/index.js
+++ b/dest/index.js
@@ -8983,10 +8983,12 @@ async function main() {
     const { decreaseStatusLines, remainingStatusLines, totalCoverageLines } = diffChecker.getCoverageDetails(!fullCoverage)
 
     const isCoverageBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(delta);
+    const isNotFullCoverageOnNewFile = diffChecker.checkIfNewFileNotFullCoverage();
+
     // Add a comment to PR with full coverage report
     let messageToPost = `## Coverage Report \n\n`
 
-    messageToPost += `* **Status**: ${isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
+    messageToPost += `* **Status**: ${isNotFullCoverageOnNewFile || isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
 
     // Add the custom message if it exists
     if (customMessage !== '') {
@@ -8999,6 +9001,9 @@ async function main() {
               '* No changes to code coverage between the master branch and the current head branch'
       messageToPost += '\n--- \n\n'
     } else {
+      if (isNotFullCoverageOnNewFile) {
+        messageToPost += `* Current PR dose not do a full coverage of new files \n`
+      }
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {
         messageToPost += `* Current PR reduces the test coverage percentage by ${delta} for some tests \n`
@@ -9060,7 +9065,7 @@ async function main() {
     )
       
     // check if the test coverage is falling below delta/tolerance.
-    if (diffChecker.checkIfNewFileNotFullCoverage() || diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
+    if (isNotFullCoverageOnNewFile || isCoverageBelowDelta) {
       throw Error(messageToPost);
     }
   } catch (error) {

--- a/dest/index.js
+++ b/dest/index.js
@@ -8972,6 +8972,7 @@ async function main() {
       pull_number: prNumber,
     });
 
+    console.log(pullRequest.data)
     const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis

--- a/dest/index.js
+++ b/dest/index.js
@@ -3861,7 +3861,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var endpoint = __nccwpck_require__(9440);
 var universalUserAgent = __nccwpck_require__(5030);
 var isPlainObject = __nccwpck_require__(9062);
-var nodeFetch = _interopDefault(__nccwpck_require__(1768));
+var nodeFetch = _interopDefault(__nccwpck_require__(467));
 var requestError = __nccwpck_require__(537);
 
 const VERSION = "5.6.2";
@@ -4079,7 +4079,212 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 1768:
+/***/ 3682:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var register = __nccwpck_require__(4670)
+var addHook = __nccwpck_require__(5549)
+var removeHook = __nccwpck_require__(6819)
+
+// bind with array of arguments: https://stackoverflow.com/a/21792913
+var bind = Function.bind
+var bindable = bind.bind(bind)
+
+function bindApi (hook, state, name) {
+  var removeHookRef = bindable(removeHook, null).apply(null, name ? [state, name] : [state])
+  hook.api = { remove: removeHookRef }
+  hook.remove = removeHookRef
+
+  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
+    var args = name ? [state, kind, name] : [state, kind]
+    hook[kind] = hook.api[kind] = bindable(addHook, null).apply(null, args)
+  })
+}
+
+function HookSingular () {
+  var singularHookName = 'h'
+  var singularHookState = {
+    registry: {}
+  }
+  var singularHook = register.bind(null, singularHookState, singularHookName)
+  bindApi(singularHook, singularHookState, singularHookName)
+  return singularHook
+}
+
+function HookCollection () {
+  var state = {
+    registry: {}
+  }
+
+  var hook = register.bind(null, state)
+  bindApi(hook, state)
+
+  return hook
+}
+
+var collectionHookDeprecationMessageDisplayed = false
+function Hook () {
+  if (!collectionHookDeprecationMessageDisplayed) {
+    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4')
+    collectionHookDeprecationMessageDisplayed = true
+  }
+  return HookCollection()
+}
+
+Hook.Singular = HookSingular.bind()
+Hook.Collection = HookCollection.bind()
+
+module.exports = Hook
+// expose constructors as a named property for TypeScript
+module.exports.Hook = Hook
+module.exports.Singular = Hook.Singular
+module.exports.Collection = Hook.Collection
+
+
+/***/ }),
+
+/***/ 5549:
+/***/ ((module) => {
+
+module.exports = addHook;
+
+function addHook(state, kind, name, hook) {
+  var orig = hook;
+  if (!state.registry[name]) {
+    state.registry[name] = [];
+  }
+
+  if (kind === "before") {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(orig.bind(null, options))
+        .then(method.bind(null, options));
+    };
+  }
+
+  if (kind === "after") {
+    hook = function (method, options) {
+      var result;
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .then(function (result_) {
+          result = result_;
+          return orig(result, options);
+        })
+        .then(function () {
+          return result;
+        });
+    };
+  }
+
+  if (kind === "error") {
+    hook = function (method, options) {
+      return Promise.resolve()
+        .then(method.bind(null, options))
+        .catch(function (error) {
+          return orig(error, options);
+        });
+    };
+  }
+
+  state.registry[name].push({
+    hook: hook,
+    orig: orig,
+  });
+}
+
+
+/***/ }),
+
+/***/ 4670:
+/***/ ((module) => {
+
+module.exports = register;
+
+function register(state, name, method, options) {
+  if (typeof method !== "function") {
+    throw new Error("method for before hook must be a function");
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  if (Array.isArray(name)) {
+    return name.reverse().reduce(function (callback, name) {
+      return register.bind(null, state, name, callback, options);
+    }, method)();
+  }
+
+  return Promise.resolve().then(function () {
+    if (!state.registry[name]) {
+      return method(options);
+    }
+
+    return state.registry[name].reduce(function (method, registered) {
+      return registered.hook.bind(null, method, options);
+    }, method)();
+  });
+}
+
+
+/***/ }),
+
+/***/ 6819:
+/***/ ((module) => {
+
+module.exports = removeHook;
+
+function removeHook(state, name, method) {
+  if (!state.registry[name]) {
+    return;
+  }
+
+  var index = state.registry[name]
+    .map(function (registered) {
+      return registered.orig;
+    })
+    .indexOf(method);
+
+  if (index === -1) {
+    return;
+  }
+
+  state.registry[name].splice(index, 1);
+}
+
+
+/***/ }),
+
+/***/ 8932:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+class Deprecation extends Error {
+  constructor(message) {
+    super(message); // Maintains proper stack trace (only available on V8)
+
+    /* istanbul ignore next */
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = 'Deprecation';
+  }
+
+}
+
+exports.Deprecation = Deprecation;
+
+
+/***/ }),
+
+/***/ 467:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4092,7 +4297,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var Stream = _interopDefault(__nccwpck_require__(2413));
 var http = _interopDefault(__nccwpck_require__(8605));
 var Url = _interopDefault(__nccwpck_require__(8835));
-var whatwgUrl = _interopDefault(__nccwpck_require__(8665));
+var whatwgUrl = _interopDefault(__nccwpck_require__(3323));
 var https = _interopDefault(__nccwpck_require__(7211));
 var zlib = _interopDefault(__nccwpck_require__(8761));
 
@@ -5758,268 +5963,14 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 3682:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-var register = __nccwpck_require__(4670)
-var addHook = __nccwpck_require__(5549)
-var removeHook = __nccwpck_require__(6819)
-
-// bind with array of arguments: https://stackoverflow.com/a/21792913
-var bind = Function.bind
-var bindable = bind.bind(bind)
-
-function bindApi (hook, state, name) {
-  var removeHookRef = bindable(removeHook, null).apply(null, name ? [state, name] : [state])
-  hook.api = { remove: removeHookRef }
-  hook.remove = removeHookRef
-
-  ;['before', 'error', 'after', 'wrap'].forEach(function (kind) {
-    var args = name ? [state, kind, name] : [state, kind]
-    hook[kind] = hook.api[kind] = bindable(addHook, null).apply(null, args)
-  })
-}
-
-function HookSingular () {
-  var singularHookName = 'h'
-  var singularHookState = {
-    registry: {}
-  }
-  var singularHook = register.bind(null, singularHookState, singularHookName)
-  bindApi(singularHook, singularHookState, singularHookName)
-  return singularHook
-}
-
-function HookCollection () {
-  var state = {
-    registry: {}
-  }
-
-  var hook = register.bind(null, state)
-  bindApi(hook, state)
-
-  return hook
-}
-
-var collectionHookDeprecationMessageDisplayed = false
-function Hook () {
-  if (!collectionHookDeprecationMessageDisplayed) {
-    console.warn('[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4')
-    collectionHookDeprecationMessageDisplayed = true
-  }
-  return HookCollection()
-}
-
-Hook.Singular = HookSingular.bind()
-Hook.Collection = HookCollection.bind()
-
-module.exports = Hook
-// expose constructors as a named property for TypeScript
-module.exports.Hook = Hook
-module.exports.Singular = Hook.Singular
-module.exports.Collection = Hook.Collection
-
-
-/***/ }),
-
-/***/ 5549:
-/***/ ((module) => {
-
-module.exports = addHook;
-
-function addHook(state, kind, name, hook) {
-  var orig = hook;
-  if (!state.registry[name]) {
-    state.registry[name] = [];
-  }
-
-  if (kind === "before") {
-    hook = function (method, options) {
-      return Promise.resolve()
-        .then(orig.bind(null, options))
-        .then(method.bind(null, options));
-    };
-  }
-
-  if (kind === "after") {
-    hook = function (method, options) {
-      var result;
-      return Promise.resolve()
-        .then(method.bind(null, options))
-        .then(function (result_) {
-          result = result_;
-          return orig(result, options);
-        })
-        .then(function () {
-          return result;
-        });
-    };
-  }
-
-  if (kind === "error") {
-    hook = function (method, options) {
-      return Promise.resolve()
-        .then(method.bind(null, options))
-        .catch(function (error) {
-          return orig(error, options);
-        });
-    };
-  }
-
-  state.registry[name].push({
-    hook: hook,
-    orig: orig,
-  });
-}
-
-
-/***/ }),
-
-/***/ 4670:
-/***/ ((module) => {
-
-module.exports = register;
-
-function register(state, name, method, options) {
-  if (typeof method !== "function") {
-    throw new Error("method for before hook must be a function");
-  }
-
-  if (!options) {
-    options = {};
-  }
-
-  if (Array.isArray(name)) {
-    return name.reverse().reduce(function (callback, name) {
-      return register.bind(null, state, name, callback, options);
-    }, method)();
-  }
-
-  return Promise.resolve().then(function () {
-    if (!state.registry[name]) {
-      return method(options);
-    }
-
-    return state.registry[name].reduce(function (method, registered) {
-      return registered.hook.bind(null, method, options);
-    }, method)();
-  });
-}
-
-
-/***/ }),
-
-/***/ 6819:
-/***/ ((module) => {
-
-module.exports = removeHook;
-
-function removeHook(state, name, method) {
-  if (!state.registry[name]) {
-    return;
-  }
-
-  var index = state.registry[name]
-    .map(function (registered) {
-      return registered.orig;
-    })
-    .indexOf(method);
-
-  if (index === -1) {
-    return;
-  }
-
-  state.registry[name].splice(index, 1);
-}
-
-
-/***/ }),
-
-/***/ 8932:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-class Deprecation extends Error {
-  constructor(message) {
-    super(message); // Maintains proper stack trace (only available on V8)
-
-    /* istanbul ignore next */
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-
-    this.name = 'Deprecation';
-  }
-
-}
-
-exports.Deprecation = Deprecation;
-
-
-/***/ }),
-
-/***/ 1223:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-var wrappy = __nccwpck_require__(2940)
-module.exports = wrappy(once)
-module.exports.strict = wrappy(onceStrict)
-
-once.proto = once(function () {
-  Object.defineProperty(Function.prototype, 'once', {
-    value: function () {
-      return once(this)
-    },
-    configurable: true
-  })
-
-  Object.defineProperty(Function.prototype, 'onceStrict', {
-    value: function () {
-      return onceStrict(this)
-    },
-    configurable: true
-  })
-})
-
-function once (fn) {
-  var f = function () {
-    if (f.called) return f.value
-    f.called = true
-    return f.value = fn.apply(this, arguments)
-  }
-  f.called = false
-  return f
-}
-
-function onceStrict (fn) {
-  var f = function () {
-    if (f.called)
-      throw new Error(f.onceError)
-    f.called = true
-    return f.value = fn.apply(this, arguments)
-  }
-  var name = fn.name || 'Function wrapped with `once`'
-  f.onceError = name + " shouldn't be called more than once"
-  f.called = false
-  return f
-}
-
-
-/***/ }),
-
-/***/ 4256:
+/***/ 2299:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 var punycode = __nccwpck_require__(4213);
-var mappingTable = __nccwpck_require__(68);
+var mappingTable = __nccwpck_require__(8661);
 
 var PROCESSING_OPTIONS = {
   TRANSITIONAL: 0,
@@ -6213,318 +6164,209 @@ module.exports.PROCESSING_OPTIONS = PROCESSING_OPTIONS;
 
 /***/ }),
 
-/***/ 4294:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-module.exports = __nccwpck_require__(4219);
-
-
-/***/ }),
-
-/***/ 4219:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ 5871:
+/***/ ((module) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(1631);
-var tls = __nccwpck_require__(4016);
-var http = __nccwpck_require__(8605);
-var https = __nccwpck_require__(7211);
-var events = __nccwpck_require__(8614);
-var assert = __nccwpck_require__(2357);
-var util = __nccwpck_require__(1669);
+var conversions = {};
+module.exports = conversions;
 
-
-exports.httpOverHttp = httpOverHttp;
-exports.httpsOverHttp = httpsOverHttp;
-exports.httpOverHttps = httpOverHttps;
-exports.httpsOverHttps = httpsOverHttps;
-
-
-function httpOverHttp(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = http.request;
-  return agent;
+function sign(x) {
+    return x < 0 ? -1 : 1;
 }
 
-function httpsOverHttp(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = http.request;
-  agent.createSocket = createSecureSocket;
-  agent.defaultPort = 443;
-  return agent;
-}
-
-function httpOverHttps(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = https.request;
-  return agent;
-}
-
-function httpsOverHttps(options) {
-  var agent = new TunnelingAgent(options);
-  agent.request = https.request;
-  agent.createSocket = createSecureSocket;
-  agent.defaultPort = 443;
-  return agent;
-}
-
-
-function TunnelingAgent(options) {
-  var self = this;
-  self.options = options || {};
-  self.proxyOptions = self.options.proxy || {};
-  self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
-  self.requests = [];
-  self.sockets = [];
-
-  self.on('free', function onFree(socket, host, port, localAddress) {
-    var options = toOptions(host, port, localAddress);
-    for (var i = 0, len = self.requests.length; i < len; ++i) {
-      var pending = self.requests[i];
-      if (pending.host === options.host && pending.port === options.port) {
-        // Detect the request to connect same origin server,
-        // reuse the connection.
-        self.requests.splice(i, 1);
-        pending.request.onSocket(socket);
-        return;
-      }
-    }
-    socket.destroy();
-    self.removeSocket(socket);
-  });
-}
-util.inherits(TunnelingAgent, events.EventEmitter);
-
-TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
-  var self = this;
-  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
-
-  if (self.sockets.length >= this.maxSockets) {
-    // We are over limit so we'll add it to the queue.
-    self.requests.push(options);
-    return;
-  }
-
-  // If we are under maxSockets create a new one.
-  self.createSocket(options, function(socket) {
-    socket.on('free', onFree);
-    socket.on('close', onCloseOrRemove);
-    socket.on('agentRemove', onCloseOrRemove);
-    req.onSocket(socket);
-
-    function onFree() {
-      self.emit('free', socket, options);
-    }
-
-    function onCloseOrRemove(err) {
-      self.removeSocket(socket);
-      socket.removeListener('free', onFree);
-      socket.removeListener('close', onCloseOrRemove);
-      socket.removeListener('agentRemove', onCloseOrRemove);
-    }
-  });
-};
-
-TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
-  var self = this;
-  var placeholder = {};
-  self.sockets.push(placeholder);
-
-  var connectOptions = mergeOptions({}, self.proxyOptions, {
-    method: 'CONNECT',
-    path: options.host + ':' + options.port,
-    agent: false,
-    headers: {
-      host: options.host + ':' + options.port
-    }
-  });
-  if (options.localAddress) {
-    connectOptions.localAddress = options.localAddress;
-  }
-  if (connectOptions.proxyAuth) {
-    connectOptions.headers = connectOptions.headers || {};
-    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
-        new Buffer(connectOptions.proxyAuth).toString('base64');
-  }
-
-  debug('making CONNECT request');
-  var connectReq = self.request(connectOptions);
-  connectReq.useChunkedEncodingByDefault = false; // for v0.6
-  connectReq.once('response', onResponse); // for v0.6
-  connectReq.once('upgrade', onUpgrade);   // for v0.6
-  connectReq.once('connect', onConnect);   // for v0.7 or later
-  connectReq.once('error', onError);
-  connectReq.end();
-
-  function onResponse(res) {
-    // Very hacky. This is necessary to avoid http-parser leaks.
-    res.upgrade = true;
-  }
-
-  function onUpgrade(res, socket, head) {
-    // Hacky.
-    process.nextTick(function() {
-      onConnect(res, socket, head);
-    });
-  }
-
-  function onConnect(res, socket, head) {
-    connectReq.removeAllListeners();
-    socket.removeAllListeners();
-
-    if (res.statusCode !== 200) {
-      debug('tunneling socket could not be established, statusCode=%d',
-        res.statusCode);
-      socket.destroy();
-      var error = new Error('tunneling socket could not be established, ' +
-        'statusCode=' + res.statusCode);
-      error.code = 'ECONNRESET';
-      options.request.emit('error', error);
-      self.removeSocket(placeholder);
-      return;
-    }
-    if (head.length > 0) {
-      debug('got illegal response body from proxy');
-      socket.destroy();
-      var error = new Error('got illegal response body from proxy');
-      error.code = 'ECONNRESET';
-      options.request.emit('error', error);
-      self.removeSocket(placeholder);
-      return;
-    }
-    debug('tunneling connection has established');
-    self.sockets[self.sockets.indexOf(placeholder)] = socket;
-    return cb(socket);
-  }
-
-  function onError(cause) {
-    connectReq.removeAllListeners();
-
-    debug('tunneling socket could not be established, cause=%s\n',
-          cause.message, cause.stack);
-    var error = new Error('tunneling socket could not be established, ' +
-                          'cause=' + cause.message);
-    error.code = 'ECONNRESET';
-    options.request.emit('error', error);
-    self.removeSocket(placeholder);
-  }
-};
-
-TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
-  var pos = this.sockets.indexOf(socket)
-  if (pos === -1) {
-    return;
-  }
-  this.sockets.splice(pos, 1);
-
-  var pending = this.requests.shift();
-  if (pending) {
-    // If we have pending requests and a socket gets closed a new one
-    // needs to be created to take over in the pool for the one that closed.
-    this.createSocket(pending, function(socket) {
-      pending.request.onSocket(socket);
-    });
-  }
-};
-
-function createSecureSocket(options, cb) {
-  var self = this;
-  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
-    var hostHeader = options.request.getHeader('host');
-    var tlsOptions = mergeOptions({}, self.options, {
-      socket: socket,
-      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
-    });
-
-    // 0 is dummy port for v0.6
-    var secureSocket = tls.connect(0, tlsOptions);
-    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
-    cb(secureSocket);
-  });
-}
-
-
-function toOptions(host, port, localAddress) {
-  if (typeof host === 'string') { // since v0.10
-    return {
-      host: host,
-      port: port,
-      localAddress: localAddress
-    };
-  }
-  return host; // for v0.11 or later
-}
-
-function mergeOptions(target) {
-  for (var i = 1, len = arguments.length; i < len; ++i) {
-    var overrides = arguments[i];
-    if (typeof overrides === 'object') {
-      var keys = Object.keys(overrides);
-      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
-        var k = keys[j];
-        if (overrides[k] !== undefined) {
-          target[k] = overrides[k];
-        }
-      }
-    }
-  }
-  return target;
-}
-
-
-var debug;
-if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-  debug = function() {
-    var args = Array.prototype.slice.call(arguments);
-    if (typeof args[0] === 'string') {
-      args[0] = 'TUNNEL: ' + args[0];
+function evenRound(x) {
+    // Round x to the nearest integer, choosing the even integer if it lies halfway between two.
+    if ((x % 1) === 0.5 && (x & 1) === 0) { // [even number].5; round down (i.e. floor)
+        return Math.floor(x);
     } else {
-      args.unshift('TUNNEL:');
+        return Math.round(x);
     }
-    console.error.apply(console, args);
-  }
-} else {
-  debug = function() {};
 }
-exports.debug = debug; // for test
+
+function createNumberConversion(bitLength, typeOpts) {
+    if (!typeOpts.unsigned) {
+        --bitLength;
+    }
+    const lowerBound = typeOpts.unsigned ? 0 : -Math.pow(2, bitLength);
+    const upperBound = Math.pow(2, bitLength) - 1;
+
+    const moduloVal = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength) : Math.pow(2, bitLength);
+    const moduloBound = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength - 1) : Math.pow(2, bitLength - 1);
+
+    return function(V, opts) {
+        if (!opts) opts = {};
+
+        let x = +V;
+
+        if (opts.enforceRange) {
+            if (!Number.isFinite(x)) {
+                throw new TypeError("Argument is not a finite number");
+            }
+
+            x = sign(x) * Math.floor(Math.abs(x));
+            if (x < lowerBound || x > upperBound) {
+                throw new TypeError("Argument is not in byte range");
+            }
+
+            return x;
+        }
+
+        if (!isNaN(x) && opts.clamp) {
+            x = evenRound(x);
+
+            if (x < lowerBound) x = lowerBound;
+            if (x > upperBound) x = upperBound;
+            return x;
+        }
+
+        if (!Number.isFinite(x) || x === 0) {
+            return 0;
+        }
+
+        x = sign(x) * Math.floor(Math.abs(x));
+        x = x % moduloVal;
+
+        if (!typeOpts.unsigned && x >= moduloBound) {
+            return x - moduloVal;
+        } else if (typeOpts.unsigned) {
+            if (x < 0) {
+              x += moduloVal;
+            } else if (x === -0) { // don't return negative zero
+              return 0;
+            }
+        }
+
+        return x;
+    }
+}
+
+conversions["void"] = function () {
+    return undefined;
+};
+
+conversions["boolean"] = function (val) {
+    return !!val;
+};
+
+conversions["byte"] = createNumberConversion(8, { unsigned: false });
+conversions["octet"] = createNumberConversion(8, { unsigned: true });
+
+conversions["short"] = createNumberConversion(16, { unsigned: false });
+conversions["unsigned short"] = createNumberConversion(16, { unsigned: true });
+
+conversions["long"] = createNumberConversion(32, { unsigned: false });
+conversions["unsigned long"] = createNumberConversion(32, { unsigned: true });
+
+conversions["long long"] = createNumberConversion(32, { unsigned: false, moduloBitLength: 64 });
+conversions["unsigned long long"] = createNumberConversion(32, { unsigned: true, moduloBitLength: 64 });
+
+conversions["double"] = function (V) {
+    const x = +V;
+
+    if (!Number.isFinite(x)) {
+        throw new TypeError("Argument is not a finite floating-point value");
+    }
+
+    return x;
+};
+
+conversions["unrestricted double"] = function (V) {
+    const x = +V;
+
+    if (isNaN(x)) {
+        throw new TypeError("Argument is NaN");
+    }
+
+    return x;
+};
+
+// not quite valid, but good enough for JS
+conversions["float"] = conversions["double"];
+conversions["unrestricted float"] = conversions["unrestricted double"];
+
+conversions["DOMString"] = function (V, opts) {
+    if (!opts) opts = {};
+
+    if (opts.treatNullAsEmptyString && V === null) {
+        return "";
+    }
+
+    return String(V);
+};
+
+conversions["ByteString"] = function (V, opts) {
+    const x = String(V);
+    let c = undefined;
+    for (let i = 0; (c = x.codePointAt(i)) !== undefined; ++i) {
+        if (c > 255) {
+            throw new TypeError("Argument is not a valid bytestring");
+        }
+    }
+
+    return x;
+};
+
+conversions["USVString"] = function (V) {
+    const S = String(V);
+    const n = S.length;
+    const U = [];
+    for (let i = 0; i < n; ++i) {
+        const c = S.charCodeAt(i);
+        if (c < 0xD800 || c > 0xDFFF) {
+            U.push(String.fromCodePoint(c));
+        } else if (0xDC00 <= c && c <= 0xDFFF) {
+            U.push(String.fromCodePoint(0xFFFD));
+        } else {
+            if (i === n - 1) {
+                U.push(String.fromCodePoint(0xFFFD));
+            } else {
+                const d = S.charCodeAt(i + 1);
+                if (0xDC00 <= d && d <= 0xDFFF) {
+                    const a = c & 0x3FF;
+                    const b = d & 0x3FF;
+                    U.push(String.fromCodePoint((2 << 15) + (2 << 9) * a + b));
+                    ++i;
+                } else {
+                    U.push(String.fromCodePoint(0xFFFD));
+                }
+            }
+        }
+    }
+
+    return U.join('');
+};
+
+conversions["Date"] = function (V, opts) {
+    if (!(V instanceof Date)) {
+        throw new TypeError("Argument is not a Date object");
+    }
+    if (isNaN(V)) {
+        return undefined;
+    }
+
+    return V;
+};
+
+conversions["RegExp"] = function (V, opts) {
+    if (!(V instanceof RegExp)) {
+        V = new RegExp(V);
+    }
+
+    return V;
+};
 
 
 /***/ }),
 
-/***/ 5030:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-function getUserAgent() {
-  if (typeof navigator === "object" && "userAgent" in navigator) {
-    return navigator.userAgent;
-  }
-
-  if (typeof process === "object" && "version" in process) {
-    return `Node.js/${process.version.substr(1)} (${process.platform}; ${process.arch})`;
-  }
-
-  return "<environment undetectable>";
-}
-
-exports.getUserAgent = getUserAgent;
-//# sourceMappingURL=index.js.map
-
-
-/***/ }),
-
-/***/ 7537:
+/***/ 8262:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-const usm = __nccwpck_require__(2158);
+const usm = __nccwpck_require__(33);
 
 exports.implementation = class URLImpl {
   constructor(constructorArgs) {
@@ -6727,15 +6569,15 @@ exports.implementation = class URLImpl {
 
 /***/ }),
 
-/***/ 3394:
+/***/ 653:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const conversions = __nccwpck_require__(6059);
-const utils = __nccwpck_require__(3185);
-const Impl = __nccwpck_require__(7537);
+const conversions = __nccwpck_require__(5871);
+const utils = __nccwpck_require__(276);
+const Impl = __nccwpck_require__(8262);
 
 const impl = utils.implSymbol;
 
@@ -6931,32 +6773,32 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8665:
+/***/ 3323:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-exports.URL = __nccwpck_require__(3394).interface;
-exports.serializeURL = __nccwpck_require__(2158).serializeURL;
-exports.serializeURLOrigin = __nccwpck_require__(2158).serializeURLOrigin;
-exports.basicURLParse = __nccwpck_require__(2158).basicURLParse;
-exports.setTheUsername = __nccwpck_require__(2158).setTheUsername;
-exports.setThePassword = __nccwpck_require__(2158).setThePassword;
-exports.serializeHost = __nccwpck_require__(2158).serializeHost;
-exports.serializeInteger = __nccwpck_require__(2158).serializeInteger;
-exports.parseURL = __nccwpck_require__(2158).parseURL;
+exports.URL = __nccwpck_require__(653).interface;
+exports.serializeURL = __nccwpck_require__(33).serializeURL;
+exports.serializeURLOrigin = __nccwpck_require__(33).serializeURLOrigin;
+exports.basicURLParse = __nccwpck_require__(33).basicURLParse;
+exports.setTheUsername = __nccwpck_require__(33).setTheUsername;
+exports.setThePassword = __nccwpck_require__(33).setThePassword;
+exports.serializeHost = __nccwpck_require__(33).serializeHost;
+exports.serializeInteger = __nccwpck_require__(33).serializeInteger;
+exports.parseURL = __nccwpck_require__(33).parseURL;
 
 
 /***/ }),
 
-/***/ 2158:
+/***/ 33:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const punycode = __nccwpck_require__(4213);
-const tr46 = __nccwpck_require__(4256);
+const tr46 = __nccwpck_require__(2299);
 
 const specialSchemes = {
   ftp: 21,
@@ -8255,7 +8097,7 @@ module.exports.parseURL = function (input, options) {
 
 /***/ }),
 
-/***/ 3185:
+/***/ 276:
 /***/ ((module) => {
 
 "use strict";
@@ -8283,199 +8125,357 @@ module.exports.implForWrapper = function (wrapper) {
 
 /***/ }),
 
-/***/ 6059:
-/***/ ((module) => {
+/***/ 1223:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+var wrappy = __nccwpck_require__(2940)
+module.exports = wrappy(once)
+module.exports.strict = wrappy(onceStrict)
+
+once.proto = once(function () {
+  Object.defineProperty(Function.prototype, 'once', {
+    value: function () {
+      return once(this)
+    },
+    configurable: true
+  })
+
+  Object.defineProperty(Function.prototype, 'onceStrict', {
+    value: function () {
+      return onceStrict(this)
+    },
+    configurable: true
+  })
+})
+
+function once (fn) {
+  var f = function () {
+    if (f.called) return f.value
+    f.called = true
+    return f.value = fn.apply(this, arguments)
+  }
+  f.called = false
+  return f
+}
+
+function onceStrict (fn) {
+  var f = function () {
+    if (f.called)
+      throw new Error(f.onceError)
+    f.called = true
+    return f.value = fn.apply(this, arguments)
+  }
+  var name = fn.name || 'Function wrapped with `once`'
+  f.onceError = name + " shouldn't be called more than once"
+  f.called = false
+  return f
+}
+
+
+/***/ }),
+
+/***/ 4294:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+module.exports = __nccwpck_require__(4219);
+
+
+/***/ }),
+
+/***/ 4219:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var conversions = {};
-module.exports = conversions;
+var net = __nccwpck_require__(1631);
+var tls = __nccwpck_require__(4016);
+var http = __nccwpck_require__(8605);
+var https = __nccwpck_require__(7211);
+var events = __nccwpck_require__(8614);
+var assert = __nccwpck_require__(2357);
+var util = __nccwpck_require__(1669);
 
-function sign(x) {
-    return x < 0 ? -1 : 1;
+
+exports.httpOverHttp = httpOverHttp;
+exports.httpsOverHttp = httpsOverHttp;
+exports.httpOverHttps = httpOverHttps;
+exports.httpsOverHttps = httpsOverHttps;
+
+
+function httpOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http.request;
+  return agent;
 }
 
-function evenRound(x) {
-    // Round x to the nearest integer, choosing the even integer if it lies halfway between two.
-    if ((x % 1) === 0.5 && (x & 1) === 0) { // [even number].5; round down (i.e. floor)
-        return Math.floor(x);
+function httpsOverHttp(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = http.request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+function httpOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https.request;
+  return agent;
+}
+
+function httpsOverHttps(options) {
+  var agent = new TunnelingAgent(options);
+  agent.request = https.request;
+  agent.createSocket = createSecureSocket;
+  agent.defaultPort = 443;
+  return agent;
+}
+
+
+function TunnelingAgent(options) {
+  var self = this;
+  self.options = options || {};
+  self.proxyOptions = self.options.proxy || {};
+  self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
+  self.requests = [];
+  self.sockets = [];
+
+  self.on('free', function onFree(socket, host, port, localAddress) {
+    var options = toOptions(host, port, localAddress);
+    for (var i = 0, len = self.requests.length; i < len; ++i) {
+      var pending = self.requests[i];
+      if (pending.host === options.host && pending.port === options.port) {
+        // Detect the request to connect same origin server,
+        // reuse the connection.
+        self.requests.splice(i, 1);
+        pending.request.onSocket(socket);
+        return;
+      }
+    }
+    socket.destroy();
+    self.removeSocket(socket);
+  });
+}
+util.inherits(TunnelingAgent, events.EventEmitter);
+
+TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
+  var self = this;
+  var options = mergeOptions({request: req}, self.options, toOptions(host, port, localAddress));
+
+  if (self.sockets.length >= this.maxSockets) {
+    // We are over limit so we'll add it to the queue.
+    self.requests.push(options);
+    return;
+  }
+
+  // If we are under maxSockets create a new one.
+  self.createSocket(options, function(socket) {
+    socket.on('free', onFree);
+    socket.on('close', onCloseOrRemove);
+    socket.on('agentRemove', onCloseOrRemove);
+    req.onSocket(socket);
+
+    function onFree() {
+      self.emit('free', socket, options);
+    }
+
+    function onCloseOrRemove(err) {
+      self.removeSocket(socket);
+      socket.removeListener('free', onFree);
+      socket.removeListener('close', onCloseOrRemove);
+      socket.removeListener('agentRemove', onCloseOrRemove);
+    }
+  });
+};
+
+TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+  var self = this;
+  var placeholder = {};
+  self.sockets.push(placeholder);
+
+  var connectOptions = mergeOptions({}, self.proxyOptions, {
+    method: 'CONNECT',
+    path: options.host + ':' + options.port,
+    agent: false,
+    headers: {
+      host: options.host + ':' + options.port
+    }
+  });
+  if (options.localAddress) {
+    connectOptions.localAddress = options.localAddress;
+  }
+  if (connectOptions.proxyAuth) {
+    connectOptions.headers = connectOptions.headers || {};
+    connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
+        new Buffer(connectOptions.proxyAuth).toString('base64');
+  }
+
+  debug('making CONNECT request');
+  var connectReq = self.request(connectOptions);
+  connectReq.useChunkedEncodingByDefault = false; // for v0.6
+  connectReq.once('response', onResponse); // for v0.6
+  connectReq.once('upgrade', onUpgrade);   // for v0.6
+  connectReq.once('connect', onConnect);   // for v0.7 or later
+  connectReq.once('error', onError);
+  connectReq.end();
+
+  function onResponse(res) {
+    // Very hacky. This is necessary to avoid http-parser leaks.
+    res.upgrade = true;
+  }
+
+  function onUpgrade(res, socket, head) {
+    // Hacky.
+    process.nextTick(function() {
+      onConnect(res, socket, head);
+    });
+  }
+
+  function onConnect(res, socket, head) {
+    connectReq.removeAllListeners();
+    socket.removeAllListeners();
+
+    if (res.statusCode !== 200) {
+      debug('tunneling socket could not be established, statusCode=%d',
+        res.statusCode);
+      socket.destroy();
+      var error = new Error('tunneling socket could not be established, ' +
+        'statusCode=' + res.statusCode);
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    if (head.length > 0) {
+      debug('got illegal response body from proxy');
+      socket.destroy();
+      var error = new Error('got illegal response body from proxy');
+      error.code = 'ECONNRESET';
+      options.request.emit('error', error);
+      self.removeSocket(placeholder);
+      return;
+    }
+    debug('tunneling connection has established');
+    self.sockets[self.sockets.indexOf(placeholder)] = socket;
+    return cb(socket);
+  }
+
+  function onError(cause) {
+    connectReq.removeAllListeners();
+
+    debug('tunneling socket could not be established, cause=%s\n',
+          cause.message, cause.stack);
+    var error = new Error('tunneling socket could not be established, ' +
+                          'cause=' + cause.message);
+    error.code = 'ECONNRESET';
+    options.request.emit('error', error);
+    self.removeSocket(placeholder);
+  }
+};
+
+TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
+  var pos = this.sockets.indexOf(socket)
+  if (pos === -1) {
+    return;
+  }
+  this.sockets.splice(pos, 1);
+
+  var pending = this.requests.shift();
+  if (pending) {
+    // If we have pending requests and a socket gets closed a new one
+    // needs to be created to take over in the pool for the one that closed.
+    this.createSocket(pending, function(socket) {
+      pending.request.onSocket(socket);
+    });
+  }
+};
+
+function createSecureSocket(options, cb) {
+  var self = this;
+  TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
+    var hostHeader = options.request.getHeader('host');
+    var tlsOptions = mergeOptions({}, self.options, {
+      socket: socket,
+      servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
+    });
+
+    // 0 is dummy port for v0.6
+    var secureSocket = tls.connect(0, tlsOptions);
+    self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+    cb(secureSocket);
+  });
+}
+
+
+function toOptions(host, port, localAddress) {
+  if (typeof host === 'string') { // since v0.10
+    return {
+      host: host,
+      port: port,
+      localAddress: localAddress
+    };
+  }
+  return host; // for v0.11 or later
+}
+
+function mergeOptions(target) {
+  for (var i = 1, len = arguments.length; i < len; ++i) {
+    var overrides = arguments[i];
+    if (typeof overrides === 'object') {
+      var keys = Object.keys(overrides);
+      for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
+        var k = keys[j];
+        if (overrides[k] !== undefined) {
+          target[k] = overrides[k];
+        }
+      }
+    }
+  }
+  return target;
+}
+
+
+var debug;
+if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
+  debug = function() {
+    var args = Array.prototype.slice.call(arguments);
+    if (typeof args[0] === 'string') {
+      args[0] = 'TUNNEL: ' + args[0];
     } else {
-        return Math.round(x);
+      args.unshift('TUNNEL:');
     }
+    console.error.apply(console, args);
+  }
+} else {
+  debug = function() {};
+}
+exports.debug = debug; // for test
+
+
+/***/ }),
+
+/***/ 5030:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+function getUserAgent() {
+  if (typeof navigator === "object" && "userAgent" in navigator) {
+    return navigator.userAgent;
+  }
+
+  if (typeof process === "object" && "version" in process) {
+    return `Node.js/${process.version.substr(1)} (${process.platform}; ${process.arch})`;
+  }
+
+  return "<environment undetectable>";
 }
 
-function createNumberConversion(bitLength, typeOpts) {
-    if (!typeOpts.unsigned) {
-        --bitLength;
-    }
-    const lowerBound = typeOpts.unsigned ? 0 : -Math.pow(2, bitLength);
-    const upperBound = Math.pow(2, bitLength) - 1;
-
-    const moduloVal = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength) : Math.pow(2, bitLength);
-    const moduloBound = typeOpts.moduloBitLength ? Math.pow(2, typeOpts.moduloBitLength - 1) : Math.pow(2, bitLength - 1);
-
-    return function(V, opts) {
-        if (!opts) opts = {};
-
-        let x = +V;
-
-        if (opts.enforceRange) {
-            if (!Number.isFinite(x)) {
-                throw new TypeError("Argument is not a finite number");
-            }
-
-            x = sign(x) * Math.floor(Math.abs(x));
-            if (x < lowerBound || x > upperBound) {
-                throw new TypeError("Argument is not in byte range");
-            }
-
-            return x;
-        }
-
-        if (!isNaN(x) && opts.clamp) {
-            x = evenRound(x);
-
-            if (x < lowerBound) x = lowerBound;
-            if (x > upperBound) x = upperBound;
-            return x;
-        }
-
-        if (!Number.isFinite(x) || x === 0) {
-            return 0;
-        }
-
-        x = sign(x) * Math.floor(Math.abs(x));
-        x = x % moduloVal;
-
-        if (!typeOpts.unsigned && x >= moduloBound) {
-            return x - moduloVal;
-        } else if (typeOpts.unsigned) {
-            if (x < 0) {
-              x += moduloVal;
-            } else if (x === -0) { // don't return negative zero
-              return 0;
-            }
-        }
-
-        return x;
-    }
-}
-
-conversions["void"] = function () {
-    return undefined;
-};
-
-conversions["boolean"] = function (val) {
-    return !!val;
-};
-
-conversions["byte"] = createNumberConversion(8, { unsigned: false });
-conversions["octet"] = createNumberConversion(8, { unsigned: true });
-
-conversions["short"] = createNumberConversion(16, { unsigned: false });
-conversions["unsigned short"] = createNumberConversion(16, { unsigned: true });
-
-conversions["long"] = createNumberConversion(32, { unsigned: false });
-conversions["unsigned long"] = createNumberConversion(32, { unsigned: true });
-
-conversions["long long"] = createNumberConversion(32, { unsigned: false, moduloBitLength: 64 });
-conversions["unsigned long long"] = createNumberConversion(32, { unsigned: true, moduloBitLength: 64 });
-
-conversions["double"] = function (V) {
-    const x = +V;
-
-    if (!Number.isFinite(x)) {
-        throw new TypeError("Argument is not a finite floating-point value");
-    }
-
-    return x;
-};
-
-conversions["unrestricted double"] = function (V) {
-    const x = +V;
-
-    if (isNaN(x)) {
-        throw new TypeError("Argument is NaN");
-    }
-
-    return x;
-};
-
-// not quite valid, but good enough for JS
-conversions["float"] = conversions["double"];
-conversions["unrestricted float"] = conversions["unrestricted double"];
-
-conversions["DOMString"] = function (V, opts) {
-    if (!opts) opts = {};
-
-    if (opts.treatNullAsEmptyString && V === null) {
-        return "";
-    }
-
-    return String(V);
-};
-
-conversions["ByteString"] = function (V, opts) {
-    const x = String(V);
-    let c = undefined;
-    for (let i = 0; (c = x.codePointAt(i)) !== undefined; ++i) {
-        if (c > 255) {
-            throw new TypeError("Argument is not a valid bytestring");
-        }
-    }
-
-    return x;
-};
-
-conversions["USVString"] = function (V) {
-    const S = String(V);
-    const n = S.length;
-    const U = [];
-    for (let i = 0; i < n; ++i) {
-        const c = S.charCodeAt(i);
-        if (c < 0xD800 || c > 0xDFFF) {
-            U.push(String.fromCodePoint(c));
-        } else if (0xDC00 <= c && c <= 0xDFFF) {
-            U.push(String.fromCodePoint(0xFFFD));
-        } else {
-            if (i === n - 1) {
-                U.push(String.fromCodePoint(0xFFFD));
-            } else {
-                const d = S.charCodeAt(i + 1);
-                if (0xDC00 <= d && d <= 0xDFFF) {
-                    const a = c & 0x3FF;
-                    const b = d & 0x3FF;
-                    U.push(String.fromCodePoint((2 << 15) + (2 << 9) * a + b));
-                    ++i;
-                } else {
-                    U.push(String.fromCodePoint(0xFFFD));
-                }
-            }
-        }
-    }
-
-    return U.join('');
-};
-
-conversions["Date"] = function (V, opts) {
-    if (!(V instanceof Date)) {
-        throw new TypeError("Argument is not a Date object");
-    }
-    if (isNaN(V)) {
-        return undefined;
-    }
-
-    return V;
-};
-
-conversions["RegExp"] = function (V, opts) {
-    if (!(V instanceof RegExp)) {
-        V = new RegExp(V);
-    }
-
-    return V;
-};
+exports.getUserAgent = getUserAgent;
+//# sourceMappingURL=index.js.map
 
 
 /***/ }),
@@ -8532,8 +8532,9 @@ var core = __nccwpck_require__(2186);
 // CONCATENATED MODULE: ./src/DiffChecker.js
 const increasedCoverageIcon = ':green_circle:'
 const decreasedCoverageIcon = ':red_circle:'
-const newCoverageIcon = ':sparkles: :new:'
+const newCoverageIcon = ':new:'
 const removedCoverageIcon = ':yellow_circle:'
+const sparkleIcon = ':sparkles:'
 /**
  * DiffChecker is the simple algorithm to compare coverage
  */
@@ -8545,7 +8546,8 @@ class DiffChecker {
     changedFiles,
     currentDirectory,
     prefixFilenameUrl,
-    prNumber
+    prNumber,
+    checkNewFileFullCoverage,
   }) {
     this.diffCoverageReport = {};
     this.delta = delta;
@@ -8554,6 +8556,7 @@ class DiffChecker {
     this.currentDirectory = currentDirectory;
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
+    this.checkNewFileFullCoverage = checkNewFileFullCoverage;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
@@ -8685,6 +8688,31 @@ class DiffChecker {
     return false
   }
 
+  /**
+   * Function to check if any new added file has not full coverage
+   */
+  checkIfNewFileNotFullCoverage() {
+    if (!this.checkNewFileFullCoverage) return false
+    const keys = Object.keys(this.diffCoverageReport);
+    return keys.some((key) => {
+      const diffCoverageData = this.diffCoverageReport[key];
+      const coverageParts = Object.values(diffCoverageData);
+      // No old coverage found so that means we added a new file coverage
+      const isFileNew = coverageParts.every((coverageData) => coverageData.oldPct === 0);
+      return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage() && this.checkOnlyChangedFiles(key);
+    });
+  }
+
+  
+  /**
+   * Function to check whether all parts has full coverage
+   * @param  {} coverageParts
+   * @param  {} {return boolen}
+   */
+  checkIfNewFileAllPartsNotFullCoverage(coverageParts) {
+    return coverageParts.some((coverageData) => coverageData.newPct < 100);
+  }
+
   isDueToRemovedLines(diffCoverageData) {
     const newCoverage = diffCoverageData.new;
     const oldCoverage = diffCoverageData.old;
@@ -8715,10 +8743,17 @@ class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
+      const newCoverageStatusIcon = `${
+        this.checkNewFileFullCoverage
+          ? this.checkIfNewFileAllPartsNotFullCoverage(Object.values(diffFileCoverageData))
+            ? decreasedCoverageIcon
+            : increasedCoverageIcon
+          : sparkleIcon
+      } ${newCoverageIcon}`;
       return {
         status: 'new',
-        statusMessage: ` ${newCoverageIcon} | **${fileNameUrl}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`
-      }
+        statusMessage: ` ${newCoverageStatusIcon} | **${fileNameUrl}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`,
+      };
     } else if (fileRemovedCoverage) {
       return {
         status: 'removed',
@@ -8930,8 +8965,16 @@ async function main() {
       .toString()
       .trim()
 
+    const labels = await githubClient.pulls.labels({
+      owner: repoOwner,
+      repo: repoName,
+      pull_number: prNumber,
+    });
+
+    const checkNewFileFullCoverage = !labels.some(label => label.name.includes('skip-new-file-full-coverage'));
+
     // Perform analysis
-    const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber });
+    const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });
     
     // Get coverage details.
     // fullCoverage: This will provide a full coverage report. You can set it to false if you do not need full coverage
@@ -9015,8 +9058,8 @@ async function main() {
     )
       
     // check if the test coverage is falling below delta/tolerance.
-    if (diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
-      throw Error(messageToPost)
+    if (diffChecker.checkIfNewFileNotFullCoverage() || diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
+      throw Error(messageToPost);
     }
   } catch (error) {
     core.setFailed(error)
@@ -9036,7 +9079,7 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
-/***/ 68:
+/***/ 8661:
 /***/ ((module) => {
 
 "use strict";

--- a/dest/index.js
+++ b/dest/index.js
@@ -8694,13 +8694,12 @@ class DiffChecker {
   checkIfNewFileNotFullCoverage() {
     if (!this.checkNewFileFullCoverage) return false
     const keys = Object.keys(this.diffCoverageReport);
-    console.log(keys)
     return keys.some((key) => {
       const diffCoverageData = this.diffCoverageReport[key];
       const coverageParts = Object.values(diffCoverageData);
       // No old coverage found so that means we added a new file coverage
       const isFileNew = coverageParts.every((coverageData) => coverageData.oldPct === 0);
-      return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage() && this.checkOnlyChangedFiles(key);
+      return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage(coverageParts) && this.checkOnlyChangedFiles(key);
     });
   }
 
@@ -8711,7 +8710,6 @@ class DiffChecker {
    * @param  {} {return boolen}
    */
   checkIfNewFileAllPartsNotFullCoverage(coverageParts) {
-    console.log(coverageParts)
     return coverageParts.some((coverageData) => coverageData.newPct < 100);
   }
 
@@ -8974,9 +8972,7 @@ async function main() {
       pull_number: prNumber,
     });
 
-    console.log(Array.prototype.some)
-    const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
-    console.log(checkNewFileFullCoverage)
+    const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/dest/index.js
+++ b/dest/index.js
@@ -8614,7 +8614,7 @@ class DiffChecker {
     const decreaseStatusLines = [];
     const remainingStatusLines = [];
     for (const key of keys) {
-      if (this.compareCoverageValues(this.diffCoverageReport[key]) !== 0) {
+      if (this.compareCoverageValues(key, this.diffCoverageReport[key]) !== 0) {
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -82,7 +82,7 @@ export class DiffChecker {
     const decreaseStatusLines = [];
     const remainingStatusLines = [];
     for (const key of keys) {
-      if (this.compareCoverageValues(this.diffCoverageReport[key]) !== 0) {
+      if (this.compareCoverageValues(key, this.diffCoverageReport[key]) !== 0) {
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -167,7 +167,7 @@ export class DiffChecker {
       const coverageParts = Object.values(diffCoverageData);
       // No old coverage found so that means we added a new file
       const newFileCoverage = coverageParts.every((coverageData) => coverageData.oldPct === 0);
-      return newFileCoverage && this.checkIfNewFileNotFullCoverageOnAnyPart(coverageParts) && this.checkOnlyChangedFiles(key);
+      return newFileCoverage && this.checkIfNewFileLacksFullCoverage(coverageParts) && this.checkOnlyChangedFiles(key);
     });
   }
 
@@ -211,14 +211,17 @@ export class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      const newCoverageStatusIcon = `${
-        this.checkNewFileFullCoverage
-          ? this.checkIfNewFileNotFullCoverageOnAnyPart(Object.values(diffFileCoverageData)) &&
-            this.checkOnlyChangedFiles(name)
-            ? decreasedCoverageIcon
-            : increasedCoverageIcon
-          : sparkleIcon
-      } ${newCoverageIcon}`;
+      let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
+      if (this.checkNewFileFullCoverage) {
+        if (
+          this.checkIfNewFileLacksFullCoverage(Object.values(diffFileCoverageData)) &&
+          this.checkOnlyChangedFiles(name)
+        ) {
+          newCoverageStatusIcon = `${decreasedCoverageIcon} ${newCoverageIcon}`;
+        } else {
+          newCoverageStatusIcon = `${increasedCoverageIcon} ${newCoverageIcon}`;
+        }
+      }
       return {
         status: 'new',
         statusMessage: ` ${newCoverageStatusIcon} | **${fileNameUrl}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`,

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -173,7 +173,7 @@ export class DiffChecker {
 
   
   /**
-   * Function to check whether any part dose not do a full coverage
+   * Function to check whether any part does not have full coverage
    * @param  {} coverageParts
    * @returns  {boolean}
    */

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -27,7 +27,8 @@ export class DiffChecker {
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    console.log(reportNewKeys, reportOldKeys)
+    reportNewKeys.forEach(v => console.log('new>>>' + v))
+    reportOldKeys.forEach(v => console.log('old>>>' + v))
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -175,7 +175,7 @@ export class DiffChecker {
   /**
    * Function to check whether any part dose not do a full coverage
    * @param  {} coverageParts
-   * @param  {} {return boolen}
+   * @returns  {boolean}
    */
   checkIfNewFileNotFullCoverageOnAnyPart(coverageParts) {
     return coverageParts.some((coverageData) => coverageData.newPct < 100);

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -38,6 +38,7 @@ export class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
+      console.log(filePath)
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -167,6 +167,7 @@ export class DiffChecker {
       const coverageParts = Object.values(diffCoverageData);
       // No old coverage found so that means we added a new file coverage
       const isFileNew = coverageParts.every((coverageData) => coverageData.oldPct === 0);
+      console.log(key, isFileNew, this.checkIfNewFileAllPartsNotFullCoverage(coverageParts), this.checkOnlyChangedFiles(key))
       return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage(coverageParts) && this.checkOnlyChangedFiles(key);
     });
   }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -27,6 +27,7 @@ export class DiffChecker {
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
+    console.log(reportNewKeys, reportOldKeys)
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -157,7 +157,7 @@ export class DiffChecker {
   }
 
   /**
-   * Function to check if any new added file dose not do a full coverage
+   * Function to check if any newly added file does not have full coverage
    */
   checkIfNewFileNotFullCoverage() {
     if (!this.checkNewFileFullCoverage) return false

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -82,7 +82,7 @@ export class DiffChecker {
     const decreaseStatusLines = [];
     const remainingStatusLines = [];
     for (const key of keys) {
-      if (this.compareCoverageValues(key, this.diffCoverageReport[key]) !== 0) {
+      if (this.compareCoverageValues(key) !== 0) {
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -246,10 +246,9 @@ export class DiffChecker {
   }
 
   compareCoverageValues(
-    file,
-    diffCoverageData
+    file
   ) {
-    const values = Object.values(diffCoverageData);
+    const values = Object.values(this.diffCoverageReport[file]);
     const noOldCoverage = values.every((part) => part.oldPct === 0);
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -165,7 +165,7 @@ export class DiffChecker {
     return keys.some((key) => {
       const diffCoverageData = this.diffCoverageReport[key];
       const coverageParts = Object.values(diffCoverageData);
-      // No old coverage found so that means we added a new file coverage
+      // No old coverage found so that means we added a new file
       const newFileCoverage = coverageParts.every((coverageData) => coverageData.oldPct === 0);
       return newFileCoverage && this.checkIfNewFileNotFullCoverageOnAnyPart(coverageParts) && this.checkOnlyChangedFiles(key);
     });

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -162,6 +162,7 @@ export class DiffChecker {
   checkIfNewFileNotFullCoverage() {
     if (!this.checkNewFileFullCoverage) return false
     const keys = Object.keys(this.diffCoverageReport);
+    console.log(keys)
     return keys.some((key) => {
       const diffCoverageData = this.diffCoverageReport[key];
       const coverageParts = Object.values(diffCoverageData);
@@ -178,6 +179,7 @@ export class DiffChecker {
    * @param  {} {return boolen}
    */
   checkIfNewFileAllPartsNotFullCoverage(coverageParts) {
+    console.log(coverageParts)
     return coverageParts.some((coverageData) => coverageData.newPct < 100);
   }
 

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -27,8 +27,6 @@ export class DiffChecker {
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
     const reportNewKeys = Object.keys(coverageReportNew)
     const reportOldKeys = Object.keys(coverageReportOld)
-    reportNewKeys.forEach(v => console.log('new>>>' + v))
-    reportOldKeys.forEach(v => console.log('old>>>' + v))
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
 
     /**
@@ -159,7 +157,7 @@ export class DiffChecker {
   }
 
   /**
-   * Function to check if any new added file has not full coverage
+   * Function to check if any new added file dose not do a full coverage
    */
   checkIfNewFileNotFullCoverage() {
     if (!this.checkNewFileFullCoverage) return false
@@ -168,19 +166,18 @@ export class DiffChecker {
       const diffCoverageData = this.diffCoverageReport[key];
       const coverageParts = Object.values(diffCoverageData);
       // No old coverage found so that means we added a new file coverage
-      const isFileNew = coverageParts.every((coverageData) => coverageData.oldPct === 0);
-      console.log(key, isFileNew, this.checkIfNewFileAllPartsNotFullCoverage(coverageParts), this.checkOnlyChangedFiles(key))
-      return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage(coverageParts) && this.checkOnlyChangedFiles(key);
+      const newFileCoverage = coverageParts.every((coverageData) => coverageData.oldPct === 0);
+      return newFileCoverage && this.checkIfNewFileNotFullCoverageOnAnyPart(coverageParts) && this.checkOnlyChangedFiles(key);
     });
   }
 
   
   /**
-   * Function to check whether all parts has full coverage
+   * Function to check whether any part dose not do a full coverage
    * @param  {} coverageParts
    * @param  {} {return boolen}
    */
-  checkIfNewFileAllPartsNotFullCoverage(coverageParts) {
+  checkIfNewFileNotFullCoverageOnAnyPart(coverageParts) {
     return coverageParts.some((coverageData) => coverageData.newPct < 100);
   }
 
@@ -216,7 +213,8 @@ export class DiffChecker {
     if (fileNewCoverage) {
       const newCoverageStatusIcon = `${
         this.checkNewFileFullCoverage
-          ? this.checkIfNewFileAllPartsNotFullCoverage(Object.values(diffFileCoverageData))
+          ? this.checkIfNewFileNotFullCoverageOnAnyPart(Object.values(diffFileCoverageData)) &&
+            this.checkOnlyChangedFiles(name)
             ? decreasedCoverageIcon
             : increasedCoverageIcon
           : sparkleIcon
@@ -248,15 +246,20 @@ export class DiffChecker {
   }
 
   compareCoverageValues(
+    file,
     diffCoverageData
   ) {
-    const keys = Object.keys(diffCoverageData)
-    for (const key of keys) {
-      if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct && !this.isDueToRemovedLines(diffCoverageData[key])) {
-        return 1
-      }
+    const values = Object.values(diffCoverageData);
+    const noOldCoverage = values.every((part) => part.oldPct === 0);
+    const noNewCoverage = values.every((part) => part.newPct === 0);
+    const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
+    const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
+
+    if (newFileWithoutCoverage || fileCoverageChanged) {
+      return 1;
     }
-    return 0
+
+    return 0;
   }
 
   getPercentage(coverageData) {

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -177,7 +177,7 @@ export class DiffChecker {
    * @param  {} coverageParts
    * @returns  {boolean}
    */
-  checkIfNewFileNotFullCoverageOnAnyPart(coverageParts) {
+  checkIfNewFileLacksFullCoverage(coverageParts) {
     return coverageParts.some((coverageData) => coverageData.newPct < 100);
   }
 

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -162,13 +162,12 @@ export class DiffChecker {
   checkIfNewFileNotFullCoverage() {
     if (!this.checkNewFileFullCoverage) return false
     const keys = Object.keys(this.diffCoverageReport);
-    console.log(keys)
     return keys.some((key) => {
       const diffCoverageData = this.diffCoverageReport[key];
       const coverageParts = Object.values(diffCoverageData);
       // No old coverage found so that means we added a new file coverage
       const isFileNew = coverageParts.every((coverageData) => coverageData.oldPct === 0);
-      return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage() && this.checkOnlyChangedFiles(key);
+      return isFileNew && this.checkIfNewFileAllPartsNotFullCoverage(coverageParts) && this.checkOnlyChangedFiles(key);
     });
   }
 
@@ -179,7 +178,6 @@ export class DiffChecker {
    * @param  {} {return boolen}
    */
   checkIfNewFileAllPartsNotFullCoverage(coverageParts) {
-    console.log(coverageParts)
     return coverageParts.some((coverageData) => coverageData.newPct < 100);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ async function main() {
       pull_number: prNumber,
     });
 
-    console.log(pullRequest.data)
+    console.log(pullRequest.data.labels, pullRequest.data.labels.some, 'some')
     const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
 
     // Perform analysis

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ async function main() {
     const repoName = github.context.repo.repo
     // get the repo owner
     const repoOwner = github.context.repo.owner
-    
     // github token
     const githubToken = core.getInput('accessToken')
     // Full coverage (true/false)

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ async function main() {
       pull_number: prNumber,
     });
 
-    const checkNewFileFullCoverage = !pullRequest.data.labels?.some(label => label.name.includes('skip-new-file-full-coverage'));
+    const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,7 @@ async function main() {
       pull_number: prNumber,
     });
 
-    console.log(Array.prototype.some)
-    const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
-    console.log(checkNewFileFullCoverage)
+    const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ async function main() {
       messageToPost += '\n--- \n\n'
     } else {
       if (isNotFullCoverageOnNewFile) {
-        messageToPost += `* Current PR dose not do a full coverage of new files \n`
+        messageToPost += `* Current PR does not have full coverage for new files \n`
       }
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {

--- a/src/index.js
+++ b/src/index.js
@@ -73,8 +73,9 @@ async function main() {
       pull_number: prNumber,
     });
 
-    console.log(pullRequest.data.labels, pullRequest.data.labels.some, 'some')
+    console.log(Array.prototype.some)
     const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
+    console.log(checkNewFileFullCoverage)
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ async function main() {
     const repoName = github.context.repo.repo
     // get the repo owner
     const repoOwner = github.context.repo.owner
+    
     // github token
     const githubToken = core.getInput('accessToken')
     // Full coverage (true/false)
@@ -66,13 +67,13 @@ async function main() {
       .toString()
       .trim()
 
-    const labels = await githubClient.pulls.labels({
+    const pullRequest = await githubClient.pulls.get({
       owner: repoOwner,
       repo: repoName,
       pull_number: prNumber,
     });
 
-    const checkNewFileFullCoverage = !labels.some(label => label.name.includes('skip-new-file-full-coverage'));
+    const checkNewFileFullCoverage = !pullRequest.data.labels?.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/src/index.js
+++ b/src/index.js
@@ -83,10 +83,12 @@ async function main() {
     const { decreaseStatusLines, remainingStatusLines, totalCoverageLines } = diffChecker.getCoverageDetails(!fullCoverage)
 
     const isCoverageBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(delta);
+    const isNotFullCoverageOnNewFile = diffChecker.checkIfNewFileNotFullCoverage();
+
     // Add a comment to PR with full coverage report
     let messageToPost = `## Coverage Report \n\n`
 
-    messageToPost += `* **Status**: ${isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
+    messageToPost += `* **Status**: ${isNotFullCoverageOnNewFile || isCoverageBelowDelta ? ':x: **Failed**' : ':white_check_mark: **Passed**'} \n`
 
     // Add the custom message if it exists
     if (customMessage !== '') {
@@ -99,6 +101,9 @@ async function main() {
               '* No changes to code coverage between the master branch and the current head branch'
       messageToPost += '\n--- \n\n'
     } else {
+      if (isNotFullCoverageOnNewFile) {
+        messageToPost += `* Current PR dose not do a full coverage of new files \n`
+      }
       // If coverage details is below delta then post a message
       if (isCoverageBelowDelta) {
         messageToPost += `* Current PR reduces the test coverage percentage by ${delta} for some tests \n`
@@ -160,7 +165,7 @@ async function main() {
     )
       
     // check if the test coverage is falling below delta/tolerance.
-    if (diffChecker.checkIfNewFileNotFullCoverage() || diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
+    if (isNotFullCoverageOnNewFile || isCoverageBelowDelta) {
       throw Error(messageToPost);
     }
   } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ async function main() {
     });
 
     console.log(pullRequest.data)
-    const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
+    const checkNewFileFullCoverage = !((pullRequest.data.labels || []).some(label => label.name.includes('skip-new-file-full-coverage')));
 
     // Perform analysis
     const diffChecker = new DiffChecker({ coverageReportNew, coverageReportOld, delta, changedFiles, currentDirectory, prefixFilenameUrl, prNumber, checkNewFileFullCoverage });

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ async function main() {
       pull_number: prNumber,
     });
 
+    console.log(pullRequest.data)
     const checkNewFileFullCoverage = !pullRequest.data.labels.some(label => label.name.includes('skip-new-file-full-coverage'));
 
     // Perform analysis


### PR DESCRIPTION
## Which problem does this PR solve?

We need always have 100 coverage for new files added

## Main changes

Update diffChecker to check a newly added file whether has full coverage. But if we have some cases that we need to ignore this, we can add a label `skip-new-file-full-coverage` for the PR to skip the checking.

## Related documents/resources

https://app.shortcut.com/tubi/story/387293/always-have-100-coverage-for-new-files-added-in-a-pr

## Suggested CR ordering of files?

n/a

## Screenshots and/or Video records (if applicable)

n/a

## Experiment (if applicable)

n/a

## How I tested it works

I use this draft PR https://github.com/adRise/www/pull/10826 to test 
- [x]  Test adding a new file with a `.spec.{ts,tsx,js,jsx}` file but not full coverage
- [x]  Test adding a new file with a `.spec.{ts,tsx,js,jsx}` file and full coverage
- [x]  Test adding a new file without a `.spec.{ts,tsx,js,jsx}` file 
- [x]  Test adding a new file without full coverage, but has label `skip-new-file-full-coverage`
