### PR TITLE
387293/feature/always have 100 coverage for new files added fix

### DIFF
--- a/dest/index.js
+++ b/dest/index.js
@@ -8570,7 +8570,7 @@ class DiffChecker {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
       if (filePath.includes('src/common/selectors/worldCup.ts')) {
-        console.log('iiiiiii', newCoverage, oldCoverage, JSON.stringify(coverageReportNew, null, 4), JSON.stringify(coverageReportOld, null, 4))
+        console.log('iiiiiii', newCoverage, oldCoverage)
       }
       this.diffCoverageReport[filePath] = {
         branches: {

--- a/dest/index.js
+++ b/dest/index.js
@@ -8743,6 +8743,7 @@ class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
+      console.log(JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (

--- a/dest/index.js
+++ b/dest/index.js
@@ -8618,6 +8618,7 @@ class DiffChecker {
     const remainingStatusLines = [];
     for (const key of keys) {
       if (this.compareCoverageValues(key) !== 0) {
+        console.log(this.diffCoverageReport[key])
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -8789,7 +8790,7 @@ class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
-
+    console.log(file, fileCoverageChanged, fileCoverageChanged)
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/dest/index.js
+++ b/dest/index.js
@@ -8568,7 +8568,7 @@ class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
-      console.log(filePath);
+      console.log(filePath)
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,
@@ -8786,6 +8786,7 @@ class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
+
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/dest/index.js
+++ b/dest/index.js
@@ -8743,7 +8743,7 @@ class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      console.log(JSON.stringify(diffFileCoverageData, null, 4))
+      console.log(name, JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (

--- a/dest/index.js
+++ b/dest/index.js
@@ -8790,7 +8790,9 @@ class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
-    console.log(file, fileCoverageChanged, fileCoverageChanged)
+    if (file.includes('common/selectors/worldCup.ts')) {
+      console.log(file, fileCoverageChanged, fileCoverageChanged)
+    }
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/dest/index.js
+++ b/dest/index.js
@@ -8557,7 +8557,6 @@ class DiffChecker {
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
-    // const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
     const reportNewKeys = Object.keys(coverageReportNew);
     const reportOldKeys = Object.keys(coverageReportOld);
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
@@ -8569,9 +8568,7 @@ class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
-      if (filePath.includes('src/common/selectors/worldCup.ts')) {
-        console.log('iiiiiii', newCoverage, oldCoverage)
-      }
+      console.log(filePath);
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,
@@ -8619,7 +8616,6 @@ class DiffChecker {
     const remainingStatusLines = [];
     for (const key of keys) {
       if (this.compareCoverageValues(key) !== 0) {
-        console.log(key, '0000', this.diffCoverageReport[key])
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -8745,7 +8741,6 @@ class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      console.log(name, '-----', JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (
@@ -8791,9 +8786,6 @@ class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
-    if (file.includes('common/selectors/worldCup.ts')) {
-      console.log(file, newFileWithoutCoverage, fileCoverageChanged)
-    }
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/dest/index.js
+++ b/dest/index.js
@@ -8720,7 +8720,7 @@ class DiffChecker {
     if (!oldCoverage || !newCoverage) return false;
 
     return newCoverage.covered < oldCoverage.covered &&
-      (oldCoverage.covered - newCoverage.covered === oldCoverage.total - newCoverage.total)
+      (oldCoverage.covered - newCoverage.covered <= oldCoverage.total - newCoverage.total)
   }
 
   /**

--- a/dest/index.js
+++ b/dest/index.js
@@ -8571,7 +8571,7 @@ class DiffChecker {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
       if (filePath.includes('src/common/selectors/worldCup.ts')) {
-        console.log('iiiiiii', newCoverage, oldCoverage)
+        console.log('iiiiiii', newCoverage, oldCoverage, JSON.stringify(coverageReportNew, null, 4), JSON.stringify(coverageReportOld, null, 4))
       }
       this.diffCoverageReport[filePath] = {
         branches: {
@@ -8793,7 +8793,7 @@ class DiffChecker {
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
     if (file.includes('common/selectors/worldCup.ts')) {
-      console.log(file, fileCoverageChanged, fileCoverageChanged)
+      console.log(file, newFileWithoutCoverage, fileCoverageChanged)
     }
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;

--- a/dest/index.js
+++ b/dest/index.js
@@ -8548,7 +8548,6 @@ class DiffChecker {
     delta,
     prefixFilenameUrl,
     prNumber,
-    repoName,
   }) {
     this.diffCoverageReport = {};
     this.delta = delta;
@@ -8558,9 +8557,9 @@ class DiffChecker {
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
-    const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
-    const reportNewKeys = Object.keys(coverageReportNew).map(getRelativePath);
-    const reportOldKeys = Object.keys(coverageReportOld).map(getRelativePath);
+    // const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
+    const reportNewKeys = Object.keys(coverageReportNew);
+    const reportOldKeys = Object.keys(coverageReportOld);
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**

--- a/dest/index.js
+++ b/dest/index.js
@@ -8570,7 +8570,9 @@ class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
-      console.log(filePath)
+      if (filePath.includes('src/common/selectors/worldCup.ts')) {
+        console.log('iiiiiii', newCoverage, oldCoverage)
+      }
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,
@@ -8618,7 +8620,7 @@ class DiffChecker {
     const remainingStatusLines = [];
     for (const key of keys) {
       if (this.compareCoverageValues(key) !== 0) {
-        console.log(this.diffCoverageReport[key])
+        console.log(key, '0000', this.diffCoverageReport[key])
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -8744,7 +8746,7 @@ class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      console.log(name, JSON.stringify(diffFileCoverageData, null, 4))
+      console.log(name, '-----', JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-cov-reporter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Produce a coverage report and provide a diff with base report",
   "main": "dest/index.js",
   "scripts": {

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -211,6 +211,7 @@ export class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
+      console.log(JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -36,7 +36,7 @@ export class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
-      console.log(filePath);
+      console.log(filePath)
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,
@@ -254,6 +254,7 @@ export class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
+
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -39,7 +39,7 @@ export class DiffChecker {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
       if (filePath.includes('src/common/selectors/worldCup.ts')) {
-        console.log('iiiiiii', newCoverage, oldCoverage)
+        console.log('iiiiiii', newCoverage, oldCoverage, JSON.stringify(coverageReportNew, null, 4), JSON.stringify(coverageReportOld, null, 4))
       }
       this.diffCoverageReport[filePath] = {
         branches: {
@@ -261,7 +261,7 @@ export class DiffChecker {
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
     if (file.includes('common/selectors/worldCup.ts')) {
-      console.log(file, fileCoverageChanged, fileCoverageChanged)
+      console.log(file, newFileWithoutCoverage, fileCoverageChanged)
     }
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -258,7 +258,9 @@ export class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
-    console.log(file, fileCoverageChanged, fileCoverageChanged)
+    if (file.includes('common/selectors/worldCup.ts')) {
+      console.log(file, fileCoverageChanged, fileCoverageChanged)
+    }
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -188,7 +188,7 @@ export class DiffChecker {
     if (!oldCoverage || !newCoverage) return false;
 
     return newCoverage.covered < oldCoverage.covered &&
-      (oldCoverage.covered - newCoverage.covered === oldCoverage.total - newCoverage.total)
+      (oldCoverage.covered - newCoverage.covered <= oldCoverage.total - newCoverage.total)
   }
 
   /**

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -38,7 +38,7 @@ export class DiffChecker {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
       if (filePath.includes('src/common/selectors/worldCup.ts')) {
-        console.log('iiiiiii', newCoverage, oldCoverage, JSON.stringify(coverageReportNew, null, 4), JSON.stringify(coverageReportOld, null, 4))
+        console.log('iiiiiii', newCoverage, oldCoverage)
       }
       this.diffCoverageReport[filePath] = {
         branches: {

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -16,7 +16,6 @@ export class DiffChecker {
     delta,
     prefixFilenameUrl,
     prNumber,
-    repoName,
   }) {
     this.diffCoverageReport = {};
     this.delta = delta;
@@ -26,9 +25,9 @@ export class DiffChecker {
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
-    const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
-    const reportNewKeys = Object.keys(coverageReportNew).map(getRelativePath);
-    const reportOldKeys = Object.keys(coverageReportOld).map(getRelativePath);
+    // const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
+    const reportNewKeys = Object.keys(coverageReportNew);
+    const reportOldKeys = Object.keys(coverageReportOld);
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
 
     /**

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -25,7 +25,6 @@ export class DiffChecker {
     this.prefixFilenameUrl = prefixFilenameUrl;
     this.prNumber = prNumber;
     this.checkNewFileFullCoverage = checkNewFileFullCoverage;
-    // const getRelativePath = (fullFilePath) => fullFilePath.split(repoName).pop();
     const reportNewKeys = Object.keys(coverageReportNew);
     const reportOldKeys = Object.keys(coverageReportOld);
     const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
@@ -37,9 +36,7 @@ export class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
-      if (filePath.includes('src/common/selectors/worldCup.ts')) {
-        console.log('iiiiiii', newCoverage, oldCoverage)
-      }
+      console.log(filePath);
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,
@@ -87,7 +84,6 @@ export class DiffChecker {
     const remainingStatusLines = [];
     for (const key of keys) {
       if (this.compareCoverageValues(key) !== 0) {
-        console.log(key, '0000', this.diffCoverageReport[key])
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -213,7 +209,6 @@ export class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      console.log(name, '-----', JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (
@@ -259,9 +254,6 @@ export class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
-    if (file.includes('common/selectors/worldCup.ts')) {
-      console.log(file, newFileWithoutCoverage, fileCoverageChanged)
-    }
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -38,7 +38,9 @@ export class DiffChecker {
     for (const filePath of reportKeys) {
       const newCoverage = coverageReportNew[filePath] || {};
       const oldCoverage = coverageReportOld[filePath] || {};
-      console.log(filePath)
+      if (filePath.includes('src/common/selectors/worldCup.ts')) {
+        console.log('iiiiiii', newCoverage, oldCoverage)
+      }
       this.diffCoverageReport[filePath] = {
         branches: {
           new: newCoverage.branches,
@@ -86,7 +88,7 @@ export class DiffChecker {
     const remainingStatusLines = [];
     for (const key of keys) {
       if (this.compareCoverageValues(key) !== 0) {
-        console.log(this.diffCoverageReport[key])
+        console.log(key, '0000', this.diffCoverageReport[key])
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -212,7 +214,7 @@ export class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      console.log(name, JSON.stringify(diffFileCoverageData, null, 4))
+      console.log(name, '-----', JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -211,7 +211,7 @@ export class DiffChecker {
 
     const fileNameUrl = this.prefixFilenameUrl !== '' ? `[${name}](${this.prefixFilenameUrl}/${this.prNumber}/lcov-report/${name === 'total' ? 'index' : name.substring(1)}.html)` : name;
     if (fileNewCoverage) {
-      console.log(JSON.stringify(diffFileCoverageData, null, 4))
+      console.log(name, JSON.stringify(diffFileCoverageData, null, 4))
       let newCoverageStatusIcon = `${sparkleIcon} ${newCoverageIcon}`
       if (this.checkNewFileFullCoverage) {
         if (

--- a/src/DiffChecker.js
+++ b/src/DiffChecker.js
@@ -86,6 +86,7 @@ export class DiffChecker {
     const remainingStatusLines = [];
     for (const key of keys) {
       if (this.compareCoverageValues(key) !== 0) {
+        console.log(this.diffCoverageReport[key])
         const diffStatus = this.createDiffLine(
           key.replace(this.currentDirectory, ''),
           this.diffCoverageReport[key]
@@ -257,7 +258,7 @@ export class DiffChecker {
     const noNewCoverage = values.every((part) => part.newPct === 0);
     const newFileWithoutCoverage = noOldCoverage && noNewCoverage && this.checkOnlyChangedFiles(file);
     const fileCoverageChanged = values.some((part) => part.oldPct !== part.newPct && !this.isDueToRemovedLines(part));
-
+    console.log(file, fileCoverageChanged, fileCoverageChanged)
     if (newFileWithoutCoverage || fileCoverageChanged) {
       return 1;
     }


### PR DESCRIPTION
#### Problem:

A quick fix for the error report on only changed files.  https://tubi.slack.com/archives/GANV2QSD6/p1667375102429459

#### Changes:
We need to use the absolute path  as the `key` in DiffChecker on L28-29. Otherwise, we are always getting the wrong reporter object on L37-38
https://github.com/adRise/jest-cov-reporter/blob/9bb4e2300a3c7f33cd58815b2fa014946bfbe027/src/DiffChecker.js#L28-L38

Please check the file.
#### How I test it:
I test it on my removing side sheet PR and test it on the old PR for testing jest-cov-reporter. 