### PR TITLE
chore: upgrade node js version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     default: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dest/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-cov-reporter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Produce a coverage report and provide a diff with base report",
   "main": "dest/index.js",
   "scripts": {


### PR DESCRIPTION
Fix this node 12 warning (https://github.com/adRise/adrise_cmsui/actions/runs/4298864345):

![image](https://user-images.githubusercontent.com/4938243/222554320-d073cc20-f8c5-437d-8f18-e6ef3928d21c.png)

Tested the upgraded version works as expected. https://github.com/adRise/adrise_cmsui/actions/runs/4318294202/jobs/7536418800#step:12:1