### PR TITLE
Upgrade Node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  NODE_VERSION: 14.17.3
+  NODE_VERSION: 20.11.1
   MASTER_SHA: ''
 
 on:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: We test it locally with act
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: jest coverage reporter
         uses: ./ # Uses an action in the root directory

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 # coverage
 debug.local.js
 tests
+coverage/*

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Produce a coverage report and provide a diff with base report",
   "main": "dest/index.js",
   "scripts": {
-    "lint": "eslint -c .eslintrc.json src",
-    "test": "jest src --coverage --verbose",
+    "lint": "eslint -c .eslintrc.js src",
+    "test": "jest src --coverage --verbose --passWithNoTests",
     "jest-dev": "jest src --coverage --verbose --watch",
     "build": "ncc build src/index.js -o dest"
   },
@@ -23,5 +23,8 @@
     "eslint": "^8.6.0",
     "jest": "^26.6.3",
     "xml2js": "^0.6.2"
+  },
+  "engines": {
+    "node": "^20.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint -c .eslintrc.js src",
     "test": "jest src --coverage --verbose --passWithNoTests",
     "jest-dev": "jest src --coverage --verbose --watch",
-    "build": "ncc build src/index.js -o dest"
+    "build": "NODE_OPTIONS=--openssl-legacy-provider ncc build src/index.js -o dest"
   },
   "repository": "git@github.com:arunshan/jest-cov-reporter.git",
   "license": "MIT",


### PR DESCRIPTION
- Upgrade to Node v20. This should remove the deprecated warnings in GitHub action job summaries.
![Screenshot 2024-05-03 at 2 22 40 PM](https://github.com/adRise/jest-cov-reporter/assets/5413624/913caf30-6eb7-4957-b1ba-7a3d702bc33f)
- Make it so lint & test scripts run & pass.
- Upgrade to checkout v4 as v3 is now deprecated as well.
- Needed to add `NODE_OPTIONS=--openssl-legacy-provider` for the build script for it to work.